### PR TITLE
Refactored Vagrantfile and site.yml

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -2,6 +2,8 @@
 ---
 - name: Install/configure servers (kafka and zookeeper)
   hosts: "{{host_inventory}}"
+  vars_files:
+    - vars/kafka.yml
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union(kafka_package_list) | union((install_packages_by_tag|default({})).kafka|default([])) }}"
   roles:

--- a/vars/kafka.yml
+++ b/vars/kafka.yml
@@ -4,9 +4,11 @@
 # kafka
 ---
 application: kafka
+# scala_version: "2.11"
+# kafka_version: "0.10.1.0"
 # kafka_distro: apache
-# kafka_url: "https://www-us.apache.org/dist/kafka/0.10.1.0/kafka_2.11-0.10.1.0.tgz"
-# kafka_url: "https://10.0.2.2/dist/kafka/0.10.1.0/kafka_2.11-0.10.1.0.tgz"
+# kafka_url: "https://www-us.apache.org/dist/kafka/{{kafka_version}}/kafka_{{scala_version}}-{{kafka_version}}.tgz"
+# kafka_url: "https://10.0.2.2/dist/kafka/{{kafka_version}}/kafka_{{scala_version}}-{{kafka_version}}.tgz"
 # kafka_dir: "/opt/kafka"
 kafka_iface: eth0
 kafka_distro: confluent


### PR DESCRIPTION
The changes in this pull request refactor the `Vagrantfile` and `site.yml` file in order to pull in default values for deployment of kafka from the newly created `vars/kafka.yml` file and to support additional vagrant flags.  Specifically:

* the `site.yml` file was changed to pull in the `vars/kafka.yml` file (in order to retrieve the default values for the parameters that *must* be defined to successfully deploy Kafka using the Ansible playbook defined in the `site.yml` file)
* the `vars/kafka.yml file was modified slightly to ensure that reasonable defaults were defined in that file for all of the parameters needed to perform an install of the Confluent Kafka installation (and also to ensure that the defaults for an Apache Kafka installation are also shown in that same file, even if they are commented out)
* Code was added to the `Vagrantfile` to monkey-patch the `OptionParser` class used to parse the command-line flags passed to the `vagrant ...` commands; the modified code passes any unrecognized options on to the underlying `vagrant` command so that the `--no-provision` flag can be passed to a `vagrant up ...` command to create, but not provision a new virtual machine.
* Changes were made to the `Vagrantfile` to override the values defined in the `vars/kafka.yml` file based on any inputs that were passed to the `vagrant ... provision` command via the `-k, --kafka-addr` and `-d, --distro` flags.

With these changes in place, we should be ready to wrap the deployment of Kafka via Vagrant in the same install wrapper that we are currently using to deploy Kafka to AWS.