### PR TITLE
additional error handling and cleanup for the dn-kafka role

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The `site.yml` file at the top-level of this repository pulls in a set of defaul
 application: kafka
 # the distribution of Kafka that should be installed (apache or confluent)
 kafka_distro: confluent
+# the directory where the Kafka logs will be written
+kafka_data_dir: /var/lib
 # the interface Kafka should listen on when running
 kafka_iface: eth0
 # the following parameters are only used when provisioning an instance
@@ -34,9 +36,22 @@ kafka_dir: "/opt/kafka"
 # but is uncommented here so that it can be used if a confluent distribution
 # is chosen when provisioning via Vagrant
 confluent_version: "3.1"
+confluent_package_name: "confluent-platform-oss-2.11"
 # these parameters are used for both confluent and apache distributions
 kafka_topics: ["metrics", "logs"]
 kafka_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
+# used to add extra repositories to the list of repositories in the
+# `local.repo` file that is deployed to a node when we're adding a
+# local repository to use in the provisioning process
+#local_repository_url: http://{{yum_repository}}/local.repo
+#local_repository_extra_keys: http://{{yum_repository}}/local-keys.json
+# used to install kafka from the RPM files in a local directory (when deploying
+# the Confluent Kafka dstribution), if it exists and is not an empty string
+local_kafka_path: ""
+# used to install kafka from the RPM files in a local gzipped tarfile
+# (when deploying the Apache Kafka dstribution), if it exists and is not
+# an empty string
+local_kafka_file: ""
 ```
 
 This default configuration defines default values for all of the parameters needed to deploy an instance of Kafka (both the Apache and the Confluent Kafka distributions are supported) to a node, including defining reasonable defaults for the network interface the Kafka instance should listen ("eth0" by default) and the topics that should automatically be create every Kafka node (the "metrics" and "logs" topics by default).  To deploy Kafka to a node the IP address "192.168.34.8" using the role in this repository (by default the Confluent Kafka distribution will be used), one would simply run a command that looks like this:
@@ -67,6 +82,8 @@ Note that in this case we are overriding the values defined in the `vars/kakfa.y
 application: kafka
 # the distribution of Kafka that should be installed (apache or confluent)
 kafka_distro: apache
+# the directory where the Kafka logs will be written
+kafka_data_dir: /var/lib
 # the interface Kafka should listen on when running
 kafka_iface: eth0
 # the following parameters are only used when provisioning an instance
@@ -81,9 +98,22 @@ kafka_dir: "/opt/kafka"
 # but is uncommented here so that it can be used if a confluent distribution
 # is chosen when provisioning via Vagrant
 confluent_version: "3.1"
+confluent_package_name: "confluent-platform-oss-2.11"
 # these parameters are used for both confluent and apache distributions
 kafka_topics: ["metrics", "logs"]
 kafka_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
+# used to add extra repositories to the list of repositories in the
+# `local.repo` file that is deployed to a node when we're adding a
+# local repository to use in the provisioning process
+#local_repository_url: http://{{yum_repository}}/local.repo
+#local_repository_extra_keys: http://{{yum_repository}}/local-keys.json
+# used to install kafka from the RPM files in a local directory (when deploying
+# the Confluent Kafka dstribution), if it exists and is not an empty string
+local_kafka_path: ""
+# used to install kafka from the RPM files in a local gzipped tarfile
+# (when deploying the Apache Kafka dstribution), if it exists and is not
+# an empty string
+local_kafka_file: ""
 ```
 
 With these changes in place, you could then use the same command (the one shown above for the default, Confluent Kafka distribution) to deploy an instance of the Apache Kafka distribution to that same node:
@@ -105,7 +135,7 @@ A Vagrantfile is included in this repository that can be used to deploy kafka to
 $ vagrant -k="192.168.34.8" -d="apache" up
 ```
 
-Note that the `-k` (or the corresponding `--kafka-addr`) flag must be used to pass an IP address into the Vagrantfile, and this IP address will be used as the IP address of the kafka server that is created by the vagrant command shown above.  In addition, the user *may* define the distribution of Kafka that they wish to deploy to that node using the `-d` (or the corresponding `--distro`) flag.  Valid values for the distribution are either `confluent` (the default) or `apache`.
+Note that the `-k` (or the corresponding `--kafka-list`) flag must be used to pass an IP address into the Vagrantfile, and this IP address will be used as the IP address of the kafka server that is created by the vagrant command shown above.  In addition, the user *may* define the distribution of Kafka that they wish to deploy to that node using the `-d` (or the corresponding `--distro`) flag.  Valid values for the distribution are either `confluent` (the default) or `apache`.
 
 If the Vagrantfile in this repository is being used to deploy the Confluent Kafka distribution to the specified node, then those are the only variables that need to be defined (the Confluent distribution is actually installed as a package, so no additional information is needed).  However, if you are deploying the Apache Kafka distribution to a node there are two additional parameters that must be defined for the playbook to succeed:  the `kafka_dir`, and `kafka_url` parameters.  As was mentioned earlier, default values for these two parameters are defined in the `vars/kafka.yml` file, and this file is pulled into the playbook contained in the `site.yml` file used by the Vagrantfile for provisioning.  As such, the Vagrantfile in this repository can be used (out of the box, so to speak) to deploy either the Confluent or Apache Kafka distributions to a node, without requiring editing of either the Vagrantfile or the `vars/kafka.yml` file.
 

--- a/site.yml
+++ b/site.yml
@@ -8,23 +8,13 @@
     - combined_package_list: "{{ (default_packages|default([])) | union(kafka_package_list) | union((install_packages_by_tag|default({})).kafka|default([])) }}"
   roles:
     - role: ensure-interfaces-up
-      tags:
-        - always
     - role: get-iface-addr
       iface_name: "{{kafka_iface}}"
-      tags:
-        - always
     - role: setup-web-proxy
-      tags:
-        - always
     - role: add-local-repository
       yum_repository: "{{yum_repo_addr}}"
-      tags:
-        - always
       when: yum_repo_addr is defined
     - role: install-packages
       package_list: "{{combined_package_list}}"
-      tags:
-        - always
     - role: dn-kafka
       kafka_addr: "{{iface_addr}}"

--- a/site.yml
+++ b/site.yml
@@ -21,7 +21,7 @@
       yum_repository: "{{yum_repo_addr}}"
       tags:
         - always
-      when: yum_repository is defined
+      when: yum_repo_addr is defined
     - role: install-packages
       package_list: "{{combined_package_list}}"
       tags:

--- a/tasks/add-kafka-topics.yml
+++ b/tasks/add-kafka-topics.yml
@@ -1,15 +1,11 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Choose a zookeeper node
+- name: Choose a zookeeper node from the ZK cluster when defined
   set_fact: zk_node={{(zookeeper_nodes|shuffle).0}}
   when: zookeeper_nodes is defined and zookeeper_nodes != []
-  tags:
-    - kafka
 - name: Set zookeeper node to localhost when not defined
   set_fact: zk_node=localhost
   when: not(zookeeper_nodes is defined and zookeeper_nodes != [])
-  tags:
-    - kafka
 - name: Create kafka topics
   become: true
   become_user: kafka
@@ -19,5 +15,3 @@
   failed_when:
     - "'already exists' not in command_result.stdout"
     - "command_result.rc != 0"
-  tags:
-    - kafka

--- a/tasks/add-kafka-user.yml
+++ b/tasks/add-kafka-user.yml
@@ -1,18 +1,14 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Create kafka group
+- block:
+  - name: Create kafka group
+    group:
+      name: kafka
+      system: yes
+  - name: Create kafka user
+    user:
+      name: kafka
+      group: kafka
+      createhome: no
+      system: yes
   become: true
-  group:
-    name: kafka
-    system: yes
-  tags:
-    - always
-- name: Create kafka user
-  become: true
-  user:
-    name: kafka
-    group: kafka
-    createhome: no
-    system: yes
-  tags:
-    - always

--- a/tasks/create-kafka-services.yml
+++ b/tasks/create-kafka-services.yml
@@ -1,32 +1,26 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Create kafka-zookeeper service file
+# if the `zookeeper_nodes` array is not defined then we're
+# performing a single-node deployment and we should configure
+# a local kafka-zookeeper service
+- block:
+  - name: Create kafka-zookeeper service file
+    template:
+      src: "../templates/{{kafka_distro}}-zookeeper.j2"
+      dest: /etc/systemd/system/kafka-zookeeper.service
+      mode: 0644
+    when: (zookeeper_nodes | default([])) == []
+  - name: Create kafka service file
+    template:
+      src: "../templates/{{kafka_distro}}-kafka.j2"
+      dest: /etc/systemd/system/kafka.service
+      mode: 0644
+  - name: Create confluent-schema-registry service file
+    template:
+      src: ../templates/confluent-schema-registry.j2
+      dest: /etc/systemd/system/confluent-schema-registry.service
+      mode: 0644
+    when: kafka_distro == "confluent"
+  - name: restart systemctl daemon
+    command: systemctl daemon-reload
   become: true
-  template:
-    src: "../templates/{{kafka_distro}}-zookeeper.j2"
-    dest: /etc/systemd/system/kafka-zookeeper.service
-    mode: 0644
-  tags:
-    - zookeeper
-- name: Create kafka service file
-  become: true
-  template:
-    src: "../templates/{{kafka_distro}}-kafka.j2"
-    dest: /etc/systemd/system/kafka.service
-    mode: 0644
-  tags:
-    - kafka
-- name: Create confluent-schema-registry service file
-  become: true
-  template:
-    src: ../templates/confluent-schema-registry.j2
-    dest: /etc/systemd/system/confluent-schema-registry.service
-    mode: 0644
-  when: kafka_distro == "confluent"
-  tags:
-    - kafka
-- name: restart systemctl daemon
-  become: true
-  command: systemctl daemon-reload
-  tags:
-    - always

--- a/tasks/enable-kafka-services.yml
+++ b/tasks/enable-kafka-services.yml
@@ -1,18 +1,15 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Enable kafka-zookeeper service on boot
+# if the `zookeeper_nodes` array is not defined then we're
+# performing a single-node deployment and we should enable
+# the local kafka-zookeeper service
+- block:
+  - name: Enable kafka-zookeeper service on boot
+    command: systemctl enable kafka-zookeeper.service
+    when: (zookeeper_nodes | default([])) == []
+  - name: Enable kafka service on boot
+    command: systemctl enable kafka.service
+  - name: Enable confluent-schema-registry service on boot
+    command: systemctl enable confluent-schema-registry.service
+    when: kafka_distro == "confluent"
   become: true
-  command: systemctl enable kafka-zookeeper.service
-  tags:
-    - zookeeper
-- name: Enable kafka service on boot
-  become: true
-  command: systemctl enable kafka.service
-  tags:
-    - kafka
-- name: Enable confluent-schema-registry service on boot
-  become: true
-  command: systemctl enable confluent-schema-registry.service
-  when: kafka_distro == "confluent"
-  tags:
-    - kafka

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,4 @@
 - include: start-kafka-services.yml static=no
 - name: Pausing before creating requested topics
   command: sleep 10
-  tags:
-    - kafka
 - include: add-kafka-topics.yml static=no

--- a/tasks/setup-apache-kafka.yml
+++ b/tasks/setup-apache-kafka.yml
@@ -1,68 +1,77 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Download kafka distribution to /tmp
-  become: true
-  get_url:
-    url: "{{kafka_url}}"
-    dest: /tmp
-    mode: 0644
-    validate_certs: no
-  environment: "{{environment_vars}}"
-  tags:
-    - always
-- name: Create "{{kafka_dir}}"
-  become: true
-  file:
-    path: "{{kafka_dir}}"
-    state: directory
-    owner: kafka
-    group: kafka
-  tags:
-    - always
-- name: Unpack kafka distribution into "{{kafka_dir}}"
-  become: true
-  unarchive:
-    copy: no
-    src: "/tmp/kafka_2.11-0.10.1.0.tgz"
-    dest: "{{kafka_dir}}"
-    extra_opts: [ "--strip-components=1" ]
-    owner: kafka
-    group: kafka
-  tags:
-    - always
-# Now that we've installed the packages that we need, setup the appropriate `log`
-# directories for Zookeeper and/or Kafka (depending on the role, or roles in the
-# case of a single-node deployment, that each node will be playing in our cluster)
-# and finish by setting up some facts that we'll need later in our playbook
+# First, setup a fact so that can test whether or not we're installing
+# Fusion from a local directory on the Ansible node (or not)
+- set_fact:
+    install_from_dir: "{{not(local_kafka_file is undefined or local_kafka_file is none or local_kafka_file | trim == '')}}"
+# if we're not installing Kafka from a local directory then we're installing
+# from a repository (either a local repository or the standard Apache Kafka
+# repository)
 - block:
-  - set_fact: log_dir_location="/var/lib"
-  - name: Set fact for the log directory location
-    set_fact: log_dir_location="{{kafka_log_dir}}"
-    when: not (kafka_log_dir is undefined or kafka_log_dir is none or kafka_log_dir | trim == '')
-  tags:
-    - always
-- name: Create apache-zookeeper log directory
+  - name: Download kafka distribution to /tmp
+    become: true
+    get_url:
+      url: "{{kafka_url}}"
+      dest: /tmp
+      mode: 0644
+      validate_certs: no
+    environment: "{{environment_vars}}"
+  - set_fact:
+      local_filename: "{{kafka_url | basename}}"
+  when: not(install_from_dir)
+# otherwise, if we're installing from a local directory on the Ansible node
+# that we're running this playbook from, copy over the files from that directory
+# to a temporary directory and and install the Confluent packages from those files
+- block:
+  - name: Copy confluent files from a local directory to /tmp
+    copy:
+      src: "{{local_kafka_file}}"
+      dest: "/tmp"
+  - set_fact:
+      local_filename: "{{local_kafka_file | basename}}"
+  when: install_from_dir
+# finally, create a directory and unpack the distribution we downloaded into
+# that directory
+- block:
+  - name: Create "{{kafka_dir}}"
+    file:
+      path: "{{kafka_dir}}"
+      state: directory
+      owner: kafka
+      group: kafka
+  - name: Unpack kafka distribution into "{{kafka_dir}}"
+    unarchive:
+      copy: no
+      src: "/tmp/{{local_filename}}"
+      dest: "{{kafka_dir}}"
+      extra_opts: [ "--strip-components=1" ]
+      owner: kafka
+      group: kafka
   become: true
-  file:
-    path: "{{log_dir_location}}/zookeeper"
-    state: directory
-    owner: kafka
-    group: kafka
-  tags:
-    - zookeeper
-- name: Create apache-kafka log directory
+# Now that we've installed the packages that we need, setup the appropriate `log`
+# directories for Kafka (and for Zookeeper in the case of a single-node deployment)
+- set_fact: log_dir_location="/var/lib"
+- name: Set fact for the log directory location
+  set_fact: log_dir_location="{{kafka_data_dir}}"
+  when: not (kafka_data_dir is undefined or kafka_data_dir is none or kafka_data_dir | trim == '')
+- block:
+  - name: Create apache-kafka log directory
+    file:
+      path: "{{log_dir_location}}/kafka"
+      state: directory
+      owner: kafka
+      group: kafka
+  - name: Create apache-zookeeper log directory
+    file:
+      path: "{{log_dir_location}}/zookeeper"
+      state: directory
+      owner: kafka
+      group: kafka
+    when: (zookeeper_nodes | default([])) == []
   become: true
-  file:
-    path: "{{log_dir_location}}/kafka"
-    state: directory
-    owner: kafka
-    group: kafka
-  tags:
-    - kafka
-- name: Set values for kafka_bin_dir and kafka_config_dir
+# finally, set values for kafka_bin_dir, kafka_config_dir, and kafka_topics_cmd
+- name: Set a few facts that are used later in the playbook
   set_fact:
     kafka_bin_dir: "{{kafka_dir}}/bin"
     kafka_config_dir: "{{kafka_dir}}/config"
     kafka_topics_cmd: "{{kafka_dir}}/bin/kafka-topics.sh"
-  tags:
-    - always

--- a/tasks/setup-apache-kafka.yml
+++ b/tasks/setup-apache-kafka.yml
@@ -34,10 +34,17 @@
 # directories for Zookeeper and/or Kafka (depending on the role, or roles in the
 # case of a single-node deployment, that each node will be playing in our cluster)
 # and finish by setting up some facts that we'll need later in our playbook
+- block:
+  - set_fact: log_dir_location="/var/lib"
+  - name: Set fact for the log directory location
+    set_fact: log_dir_location="{{kafka_log_dir}}"
+    when: not (kafka_log_dir is undefined or kafka_log_dir is none or kafka_log_dir | trim == '')
+  tags:
+    - always
 - name: Create apache-zookeeper log directory
   become: true
   file:
-    path: "{{kafka_log_dir}}/zookeeper"
+    path: "{{log_dir_location}}/zookeeper"
     state: directory
     owner: kafka
     group: kafka
@@ -46,7 +53,7 @@
 - name: Create apache-kafka log directory
   become: true
   file:
-    path: "{{kafka_log_dir}}/kafka"
+    path: "{{log_dir_location}}/kafka"
     state: directory
     owner: kafka
     group: kafka

--- a/tasks/setup-confluent-kafka.yml
+++ b/tasks/setup-confluent-kafka.yml
@@ -32,7 +32,7 @@
       mode: 0644
   when: not(install_from_dir) and (local_confluent_repository is undefined or not(local_confluent_repository))
   tags:
-  - always
+    - always
 # if we're installing from a repository (either a local repository or the standard
 # Confluent repository), then install the Confluent package from that repository
 - block:
@@ -53,15 +53,11 @@
     copy:
       src: "{{local_kafka_package_path}}"
       dest: "/tmp"
-    tags:
-      - always
   - name: Get a list of the packages copied over
     find:
       paths: "/tmp/{{local_kafka_package_path.split('/')[-1]}}"
       patterns: "*.rpm"
     register: rpm_list
-    tags:
-      - always
   - name: Install all of the packages copied over
     become: true
     yum:
@@ -74,19 +70,26 @@
 # directories for Zookeeper and/or Kafka (depending on the role, or roles in the
 # case of a single-node deployment, that each node will be playing in our cluster)
 # and finish by setting up some facts that we'll need later in our playbook
-- name: Create kafka-zookeeper log directory
+- block:
+  - set_fact: log_dir_location="/var/lib"
+  - name: Set fact for the log directory location
+    set_fact: log_dir_location="{{kafka_log_dir}}"
+    when: not (kafka_log_dir is undefined or kafka_log_dir is none or kafka_log_dir | trim == '')
+  tags:
+    - always
+- name: "Create {{log_dir_location}}/zookeeper directory"
   become: true
   file:
-    path: "{{kafka_log_dir}}/zookeeper"
+    path: "{{log_dir_location}}/zookeeper"
     state: directory
     owner: kafka
     group: kafka
   tags:
     - zookeeper
-- name: Create confluent-kafka log directory
+- name: "Create {{log_dir_location}}/kafka directory"
   become: true
   file:
-    path: "{{kafka_log_dir}}/kafka"
+    path: "{{log_dir_location}}/kafka"
     state: directory
     owner: kafka
     group: kafka

--- a/tasks/setup-confluent-kafka.yml
+++ b/tasks/setup-confluent-kafka.yml
@@ -3,15 +3,12 @@
 # First, setup a couple of facts so that can test whether or not a local Confluent
 # repository link was provided and we also know if we're installing Confluent
 # from a local directory on the Ansible node (or not)
-- block:
-  - set_fact:
-      local_confluent_repository: true
-      when: item.key == 'confluent'
-      with_dict: "{{local_repository_keys | default({})}}"
-  - set_fact:
-      install_from_dir: "{{not(local_kafka_package_path is undefined or local_kafka_package_path is none or local_kafka_package_path | trim == '')}}"
-  tags:
-    - always
+- set_fact:
+    local_confluent_repository: true
+    when: item.key == 'confluent'
+    with_dict: "{{local_repository_keys | default({})}}"
+- set_fact:
+    install_from_dir: "{{not(local_kafka_path is undefined or local_kafka_path is none or local_kafka_path | trim == '')}}"
 # if we're not installing confluent from a local directory and either a local repository
 # wasn't specified or a local repository was specified but the key for the confluent packages
 # wasn't found in the list of keys retrieved from that repository, then we should setup our
@@ -31,31 +28,27 @@
       dest: /etc/yum.repos.d/confluent.repo
       mode: 0644
   when: not(install_from_dir) and (local_confluent_repository is undefined or not(local_confluent_repository))
-  tags:
-    - always
 # if we're installing from a repository (either a local repository or the standard
 # Confluent repository), then install the Confluent package from that repository
 - block:
   - name: Install confluent from repository
     yum:
-      name: confluent-platform-oss-2.11
+      name: "{{confluent_package_name}}"
       state: present
     environment: "{{environment_vars}}"
   become: true
   when: not(install_from_dir)
-  tags:
-    - always
 # otherwise, if we're installing from a local directory on the Ansible node
 # that we're running this playbook from, copy over the files from that directory
 # to a temporary directory and and install the Confluent packages from those files
 - block:
   - name: Copy confluent files from a local directory to /tmp on remote machine
     copy:
-      src: "{{local_kafka_package_path}}"
+      src: "{{local_kafka_path}}"
       dest: "/tmp"
   - name: Get a list of the packages copied over
     find:
-      paths: "/tmp/{{local_kafka_package_path | basename}}"
+      paths: "/tmp/{{local_kafka_path | basename}}"
       patterns: "*.rpm"
     register: rpm_list
   - name: Install all of the packages copied over
@@ -64,51 +57,40 @@
       name: "{{rpm_list.files | map(attribute='path') | list | join(',')}}"
       state: present
   when: install_from_dir
-  tags:
-    - always
 # Now that we've installed the packages that we need, setup the appropriate `log`
-# directories for Zookeeper and/or Kafka (depending on the role, or roles in the
-# case of a single-node deployment, that each node will be playing in our cluster)
-# and finish by setting up some facts that we'll need later in our playbook
+# directories for Kafka (and for Zookeeper in the case of a single-node deployment);
+# finally, finish by setting up some facts that we'll need later in our playbook
+- set_fact: log_dir_location="/var/lib"
+- name: Set fact for the log directory location
+  set_fact: log_dir_location="{{kafka_data_dir}}"
+  when: not (kafka_data_dir is undefined or kafka_data_dir is none or kafka_data_dir | trim == '')
 - block:
-  - set_fact: log_dir_location="/var/lib"
-  - name: Set fact for the log directory location
-    set_fact: log_dir_location="{{kafka_log_dir}}"
-    when: not (kafka_log_dir is undefined or kafka_log_dir is none or kafka_log_dir | trim == '')
-  tags:
-    - always
-- name: "Create {{log_dir_location}}/zookeeper directory"
+  - name: "Create {{log_dir_location}}/kafka directory"
+    become: true
+    file:
+      path: "{{log_dir_location}}/kafka"
+      state: directory
+      owner: kafka
+      group: kafka
+  - name: Create /var/log/kafka directory
+    file:
+      path: /var/log/kafka
+      state: directory
+      owner: kafka
+      group: kafka
+  - name: "Create {{log_dir_location}}/zookeeper directory"
+    file:
+      path: "{{log_dir_location}}/zookeeper"
+      state: directory
+      owner: kafka
+      group: kafka
+    when: (zookeeper_nodes | default([])) == []
   become: true
-  file:
-    path: "{{log_dir_location}}/zookeeper"
-    state: directory
-    owner: kafka
-    group: kafka
-  tags:
-    - zookeeper
-- name: "Create {{log_dir_location}}/kafka directory"
-  become: true
-  file:
-    path: "{{log_dir_location}}/kafka"
-    state: directory
-    owner: kafka
-    group: kafka
-  tags:
-    - kafka
-- name: Create /var/log/kafka directory
-  become: true
-  file:
-    path: /var/log/kafka
-    state: directory
-    owner: kafka
-    group: kafka
-  tags:
-    - always
-- name: Set values for kafka_bin_dir and kafka_config_dir
+# finally, set values for kafka_bin_dir, kafka_config_dir, kafka_topics_cmd, and
+# schema_registry_config_dir
+- name: Set a few facts that are used later in the playbook
   set_fact:
     kafka_bin_dir: "/usr/bin"
     kafka_config_dir: "/etc/kafka"
     kafka_topics_cmd: "kafka-topics"
     schema_registry_config_dir: "/etc/schema-registry"
-  tags:
-    - always

--- a/tasks/setup-confluent-kafka.yml
+++ b/tasks/setup-confluent-kafka.yml
@@ -55,7 +55,7 @@
       dest: "/tmp"
   - name: Get a list of the packages copied over
     find:
-      paths: "/tmp/{{local_kafka_package_path.split('/')[-1]}}"
+      paths: "/tmp/{{local_kafka_package_path | basename}}"
       patterns: "*.rpm"
     register: rpm_list
   - name: Install all of the packages copied over

--- a/tasks/setup-kafka-server-properties.yml
+++ b/tasks/setup-kafka-server-properties.yml
@@ -13,7 +13,7 @@
   lineinfile:
     dest: "{{kafka_config_dir}}/server.properties"
     regexp: "^log.dirs"
-    line: "log.dirs={{kafka_log_dir}}/kafka"
+    line: "log.dirs={{log_dir_location}}/kafka"
   tags:
     - kafka
 - name: Setup host.name for kafka cluster
@@ -67,7 +67,7 @@
   lineinfile:
     dest: "{{kafka_config_dir}}/zookeeper.properties"
     regexp: "^dataDir"
-    line: "dataDir={{kafka_log_dir}}/zookeeper"
+    line: "dataDir={{log_dir_location}}/zookeeper"
   tags:
     - zookeeper
 - name: "Configure the zookeeper cluster timeouts"
@@ -94,7 +94,7 @@
 - name: "Setup the 'myid' file for this zookeeper node"
   become: true
   lineinfile:
-    dest: "{{kafka_log_dir}}/zookeeper/myid"
+    dest: "{{log_dir_location}}/zookeeper/myid"
     create: yes
     regexp: "^[0-9]"
     line: "{{item.0}}"

--- a/tasks/setup-kafka-server-properties.yml
+++ b/tasks/setup-kafka-server-properties.yml
@@ -1,104 +1,58 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Configure kafka server instance
+# first, configure our Kafka server instance by setting up
+# the server.properties file and schema-registry.properties
+# files correctly
+- block:
+  - name: Configure kafka server instance listener address
+    replace:
+      dest: "{{kafka_config_dir}}/server.properties"
+      regexp: '^\#(([a-zA-Z]*.?)listeners=PLAINTEXT://).*(:9092)$'
+      replace: '\g<1>{{kafka_addr}}\g<3>'
+  - name: Configure server to use the defined data directory
+    lineinfile:
+      dest: "{{kafka_config_dir}}/server.properties"
+      regexp: "^log.dirs"
+      line: "log.dirs={{log_dir_location}}/kafka"
+  - name: Setup host.name if deploying a kafka cluster
+    lineinfile:
+      dest: "{{kafka_config_dir}}/server.properties"
+      regexp: "^host.name="
+      line: "host.name={{kafka_addr}}"
+    when: (zookeeper_nodes | default([])) != []
+  - name: Setup broker.id if deploying kafka cluster
+    lineinfile:
+      dest: "{{kafka_config_dir}}/server.properties"
+      regexp: "^broker.id="
+      line: "broker.id={{item.0}}"
+    with_indexed_items: "{{host_inventory}}"
+    when: "'{{iface_addr}}' == '{{item.1}}'"
+  - name: setup confluent-schema-registry listener if deploying a Confluent cluster
+    replace:
+      dest: "{{schema_registry_config_dir}}/schema-registry.properties"
+      regexp: '^(listeners=http://)0.0.0.0(.*)$'
+      replace: '\g<1>{{kafka_addr}}\g<2>'
+    when: schema_registry_config_dir is defined and zookeeper_nodes is defined and zookeeper_nodes != []
+  - name: setup kafkastore connection URL if deploying a Confluent cluster
+    replace:
+      dest: "{{schema_registry_config_dir}}/schema-registry.properties"
+      regexp: '^(kafkastore.connection.url=)localhost(.*)$'
+      replace: '\g<1>{{(zookeeper_nodes|shuffle).0}}\g<2>'
+    when: schema_registry_config_dir is defined and zookeeper_nodes is defined and zookeeper_nodes != []
+  - name: Setup zookeeper.connect value if binding to an external zookeeper ensemble
+    lineinfile:
+      dest: "{{kafka_config_dir}}/server.properties"
+      regexp: "^zookeeper.connect"
+      line: "zookeeper.connect={{(zookeeper_nodes | default([])) | join(':2181,')}}:2181"
+    when: (zookeeper_nodes | default([])) != []
   become: true
-  replace:
-    dest: "{{kafka_config_dir}}/server.properties"
-    regexp: '^\#(([a-zA-Z]*.?)listeners=PLAINTEXT://).*(:9092)$'
-    replace: '\g<1>{{kafka_addr}}\g<3>'
-  tags:
-    - kafka
-- name: Configure server to use that data directory
-  become: true
-  lineinfile:
-    dest: "{{kafka_config_dir}}/server.properties"
-    regexp: "^log.dirs"
-    line: "log.dirs={{log_dir_location}}/kafka"
-  tags:
-    - kafka
-- name: Setup host.name for kafka cluster
-  become: true
-  lineinfile:
-    dest: "{{kafka_config_dir}}/server.properties"
-    regexp: "^host.name="
-    line: "host.name={{kafka_addr}}"
-  when: (zookeeper_nodes | default([])) != []
-  tags:
-    - kafka
-- name: Setup broker.id for kafka cluster
-  become: true
-  lineinfile:
-    dest: "{{kafka_config_dir}}/server.properties"
-    regexp: "^broker.id="
-    line: "broker.id={{item.0}}"
-  with_indexed_items: "{{host_inventory}}"
-  when: "'{{iface_addr}}' == '{{item.1}}'"
-  tags:
-    - kafka
-- name: setup confluent-schema-registry listener if deploying a clustered confluent distribution
-  become: true
-  replace:
-    dest: "{{schema_registry_config_dir}}/schema-registry.properties"
-    regexp: '^(listeners=http://)0.0.0.0(.*)$'
-    replace: '\g<1>{{kafka_addr}}\g<2>'
-  when: schema_registry_config_dir is defined and zookeeper_nodes is defined and zookeeper_nodes != []
-  tags:
-    - kafka
-- name: setup kafkastore connection URL if deploying a clustered confluent distribution
-  become: true
-  replace:
-    dest: "{{schema_registry_config_dir}}/schema-registry.properties"
-    regexp: '^(kafkastore.connection.url=)localhost(.*)$'
-    replace: '\g<1>{{(zookeeper_nodes|shuffle).0}}\g<2>'
-  when: schema_registry_config_dir is defined and zookeeper_nodes is defined and zookeeper_nodes != []
-  tags:
-    - kafka
-- name: Setup kafka configuration for zookeeper cluster
-  become: true
-  lineinfile:
-    dest: "{{kafka_config_dir}}/server.properties"
-    regexp: "^zookeeper.connect"
-    line: "zookeeper.connect={{(zookeeper_nodes | default([])) | join(':2181,')}}:2181"
-  when: (zookeeper_nodes | default([])) != []
-  tags:
-    - kafka
-- name: Configure zookeeper server to use that data directory
+# then, if a Zookeeper cluster was not passed in using the zookeeper_nodes array,
+# we're performing a single-node deployment so we should configure the local zookeeper
+# instance accordingly
+- name: Configure bundled zookeeper instance to use the defined data directory
   become: true
   lineinfile:
     dest: "{{kafka_config_dir}}/zookeeper.properties"
     regexp: "^dataDir"
     line: "dataDir={{log_dir_location}}/zookeeper"
-  tags:
-    - zookeeper
-- name: "Configure the zookeeper cluster timeouts"
-  become: true
-  lineinfile:
-    dest: "{{kafka_config_dir}}/zookeeper.properties"
-    regexp: "^{{item.key}}"
-    line: "{{item.key}}={{item.val}}"
-  with_items:
-    - { key: 'initLimit', val: '5' }
-    - { key: 'syncLimit', val: '2' }
-  when: (zookeeper_nodes | default([])) != []
-  tags:
-    - zookeeper
-- name: "Configure the zookeeper cluster addresses"
-  become: true
-  lineinfile:
-    dest: "{{kafka_config_dir}}/zookeeper.properties"
-    regexp: "^server.{{item.0}}"
-    line: "server.{{item.0}}={{item.1}}:2888:3888"
-  with_indexed_items: "{{zookeeper_nodes | default([])}}"
-  tags:
-    - zookeeper
-- name: "Setup the 'myid' file for this zookeeper node"
-  become: true
-  lineinfile:
-    dest: "{{log_dir_location}}/zookeeper/myid"
-    create: yes
-    regexp: "^[0-9]"
-    line: "{{item.0}}"
-  with_indexed_items: "{{zookeeper_nodes | default([])}}"
-  when: "'{{iface_addr}}' == '{{item.1}}'"
-  tags:
-    - zookeeper
+  when: (zookeeper_nodes | default([])) == []

--- a/tasks/start-kafka-services.yml
+++ b/tasks/start-kafka-services.yml
@@ -1,28 +1,20 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Start kafka-zookeeper service
+# start up the appropriate services, including the bundled
+# kafka-zookeeper service if we are performing a single-node
+# kafka deployment
+- block:
+  - name: Start bundled kafka-zookeeper service
+    command: systemctl start kafka-zookeeper.service
+    when: (zookeeper_nodes | default([])) == []
+  - name: Pause before starting kafka service
+    command: sleep 10
+  - name: Start kafka service
+    command: systemctl start kafka.service
+  - name: Pause before starting confluent-schema-registry service
+    command: sleep 10
+    when: kafka_distro == "confluent"
+  - name: Start confluent-schema-registry service
+    command: systemctl start confluent-schema-registry.service
+    when: kafka_distro == "confluent"
   become: true
-  command: systemctl start kafka-zookeeper.service
-  tags:
-    - zookeeper
-- name: Pause before starting kafka service
-  become: true
-  command: sleep 10
-  tags:
-    - kafka
-- name: Start kafka service
-  become: true
-  command: systemctl start kafka.service
-  tags:
-    - kafka
-- name: Pause before starting confluent-schema-registry service
-  command: sleep 10
-  when: kafka_distro == "confluent"
-  tags:
-    - kafka
-- name: Start confluent-schema-registry service
-  become: true
-  command: systemctl start confluent-schema-registry.service
-  when: kafka_distro == "confluent"
-  tags:
-    - kafka

--- a/vars/kafka.yml
+++ b/vars/kafka.yml
@@ -9,7 +9,7 @@ application: kafka
 kafka_distro: confluent
 
 # the directory where the Kafka logs will be written
-kafka_log_dir: /var/lib
+kafka_data_dir: /var/lib
 
 # the interface Kafka should listen on when running
 kafka_iface: eth0
@@ -27,6 +27,7 @@ kafka_dir: "/opt/kafka"
 # but is uncommented here so that it can be used if a confluent distribution
 # is chosen when provisioning via Vagrant
 confluent_version: "3.1"
+confluent_package_name: "confluent-platform-oss-2.11"
 
 # these parameters are used for both confluent and apache distributions
 kafka_topics: ["metrics", "logs"]
@@ -38,5 +39,11 @@ kafka_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
 #local_repository_url: http://{{yum_repository}}/local.repo
 #local_repository_extra_keys: http://{{yum_repository}}/local-keys.json
 
-# used to install kafka from the RPM files in a local directory (if it exists)
-local_kafka_package_path: ""
+# used to install kafka from the RPM files in a local directory (when deploying
+# the Confluent Kafka dstribution), if it exists and is not an empty string
+local_kafka_path: ""
+
+# used to install kafka from the RPM files in a local gzipped tarfile
+# (when deploying the Apache Kafka dstribution), if it exists and is not
+# an empty string
+local_kafka_file: ""


### PR DESCRIPTION
This PR is more of a housekeeping PR than anything else.  It contains a few bug fixes that were discovered when porting the changes from the previous PR submitted against this repository to the `dn-solr` repository.  Specifically, this PR:

* modifies the Vagrantfile's `-n, --node-list` flag so that it only takes a single address, not a list of addresses; consequently the flag has been renamed as the `-n, --node` flag.
* cleans up some of the comments in the `Vagrantfile`
* adds additional error handling to the command-line input processing in the `Vagrantfile`
* modifies the command-line usage of the `Vagrantfile` so that the `-k, --kafka-list` and `-z, --zookeeper-list` command-line flags are used for *all* multi-node commands and the `-n, --node` flag is only used for commands that are targeting a single node; this required changes to the structure of how these command-line options are used, but will provide the capabilities we need when deploying a Solr cluster using the `dn-solr` role (where the Zookeeper nodes and Solr nodes are different; Solr nodes require more memory than Zookeeper nodes so we must identify which are which when creating the VMs that will be made into Zookeeper and Solr nodes.
* cleans up a few of the task files in the `dn-kafka` role to handle potential errors that a user might make in the values passed into the role's playbook

With these changes in place, we can now deploy Kafka (and Zookeeper) clusters much more simply; for example, we can create a new Zookeeper cluster with a command like this:

```bash
$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" up
...
```

Then create a new Kafka cluster and configure it to use the Zookeeper cluster we just provided with a command like this:

```bash
$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" -k="192.168.34.8,192.168.34.9,192.168.34.10" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" --kafka-only up
...
```

Alternatively, both clusters could be created (and configured) in one command as follows:

```bash
$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" -k="192.168.34.8,192.168.34.9,192.168.34.10" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" up
...
```

Or we could split up the creation of the VMs from the provisioning of those VMs:

```bash
$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" up --no-provision
...
$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" provision
...
$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" -k="192.168.34.8,192.168.34.9,192.168.34.10" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" --kafka-only up --no-provision
...
$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" -k="192.168.34.8,192.168.34.9,192.168.34.10" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" --kafka-only provision
...
```

and, of course, we can collapse that down into two commands, one that created the VMs for the Kafka and Zookeeper nodes and another that provisions all of those VMs (first the Zookeeper nodes, then the Kafka nodes):

```bash
$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" -k="192.168.34.8,192.168.34.9,192.168.34.10" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" up --no-provision
...
$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" -k="192.168.34.8,192.168.34.9,192.168.34.10" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" provision
...
```

Finally, a single node Kafka deployment can be made by using the `-n, --node` flag:

```bash
$ vagrant -n="192.168.34.21" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" up
```

And, as before, that single command can be broken up into two commands, one that creates the VM that will be needed for our Kafka deployment and another that provisions and configures that node with both Zookeeper and Kafka:

```bash
$ vagrant -n="192.168.34.21" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" up --no-provision
...
$ vagrant -n="192.168.34.21" -y=192.168.34.254 -l=/tmp/local-yum-files/confluent -r="/data" provision
...
```