### PR TITLE
Adds support for separation of the api and data network

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,11 +92,11 @@ optparse = OptionParser.new do |opts|
     options[:local_kafka_dist] = local_kafka_dist.gsub(/^=/,'')
   end
 
-  options[:yum_repo_addr] = nil
-  opts.on( '-y', '--yum-repo-host REPO_HOST', 'Local yum repository hostname/address' ) do |yum_repo_addr|
+  options[:yum_repo_url] = nil
+  opts.on( '-y', '--yum-url URL', 'Local yum repository URL' ) do |yum_repo_url|
     # while parsing, trim an '=' prefix character off the front of the string if it exists
-    # (would occur if the value was passed using an option flag like '-y=192.168.1.128')
-    options[:yum_repo_addr] = yum_repo_addr.gsub(/^=/,'')
+    # (would occur if the value was passed using an option flag like '-y=http://192.168.1.128/centos')
+    options[:yum_repo_url] = yum_repo_url.gsub(/^=/,'')
   end
 
   options[:kafka_data_dir] = nil
@@ -258,10 +258,9 @@ if provisioning_command || ip_required
   end
 end
 
-# if a yum repository address was passed in, check and make sure it's a valid
-# IPv4 address
-if options[:yum_repo_addr] && !(options[:yum_repo_addr] =~ Resolv::IPv4::Regex)
-  print "ERROR; input yum repository address '#{options[:yum_repo_addr]}' is not a valid IP address\n"
+# if a yum repository address was passed in, check and make sure it's a valid URL
+if options[:yum_repo_url] && !(options[:yum_repo_url] =~ URI::regexp)
+  print "ERROR; input yum repository URL '#{options[:yum_repo_url]}' is not a valid URL\n"
   exit 6
 end
 
@@ -304,8 +303,14 @@ if kafka_addr_array.size > 0
     # `site.yml` playbook
     kafka_addr_array.each do |machine_addr|
       config.vm.define machine_addr do |machine|
-        # setup a private network for this machine
-        machine.vm.network "private_network", ip: machine_addr
+        # Create a two private networks, which each allow host-only access to the machine
+        # using a specific IP.
+        if machine_addr
+          config.vm.network "private_network", ip: machine_addr
+          split_addr = machine_addr.split('.')
+          api_addr = (split_addr[0..1] + [(split_addr[2].to_i + 10).to_s] + [split_addr[3]]).join('.')
+          config.vm.network "private_network", ip: api_addr
+        end
         # if it's the last node in the list if input addresses, then provision
         # all of the nodes simultaneously (if the `--no-provision` flag was not
         # set, of course)
@@ -328,9 +333,10 @@ if kafka_addr_array.size > 0
                 proxy_username: proxy_username,
                 proxy_password: proxy_password
               },
-              kafka_iface: "eth1",
+              data_iface: "eth1",
+              api_iface: "eth2",
               kafka_distro: options[:kafka_distro],
-              yum_repo_addr: options[:yum_repo_addr],
+              yum_repo_url: options[:yum_repo_url],
               host_inventory: kafka_addr_array,
               reset_proxy_settings: options[:reset_proxy_settings],
               inventory_type: "static"

--- a/site.yml
+++ b/site.yml
@@ -126,7 +126,7 @@
       run_once: true
 
 # Collect some Zookeeper related facts and determine the "private" IP addresses of
-# the nodes in the Zookeeper ensemble (from their "public" IP addresses and the `kafka_iface`
+# the nodes in the Zookeeper ensemble (from their "public" IP addresses and the `data_iface`
 # variable that was passed in as part of this playbook run) if a list of "public"  Zookeeper
 # IP addresses was passed in.
 - name: Gather facts from Zookeeper host group (if defined)
@@ -149,7 +149,7 @@
   # from our Kafka node(s)
   pre_tasks:
     - set_fact:
-        zk_nodes: "{{zookeeper_nodes | map('extract', hostvars, [('ansible_' + kafka_iface), 'ipv4', 'address']) | list}}"
+        zk_nodes: "{{(zookeeper_nodes | default([])) | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
     - name: Ensure the network interfaces are up on our Kafka node(s)
       service:
         name: network
@@ -161,12 +161,15 @@
   # deploy and configure Kafka
   roles:
     - role: get-iface-addr
-      iface_name: "{{kafka_iface}}"
+      iface_name: "{{data_iface}}"
+      as_fact: "data_addr"
+    - role: get-iface-addr
+      iface_name: "{{api_iface}}"
+      as_fact: "api_addr"
     - role: setup-web-proxy
     - role: add-local-repository
-      yum_repository: "{{yum_repo_addr}}"
-      when: yum_repo_addr is defined
+      yum_repository: "{{yum_repo_url}}"
+      when: yum_repo_url is defined
     - role: install-packages
       package_list: "{{combined_package_list}}"
     - role: dn-kafka
-      kafka_addr: "{{iface_addr}}"

--- a/tasks/setup-apache-kafka.yml
+++ b/tasks/setup-apache-kafka.yml
@@ -27,6 +27,7 @@
     copy:
       src: "{{local_kafka_file}}"
       dest: "/tmp"
+      mode: 0644
   - set_fact:
       local_filename: "{{local_kafka_file | basename}}"
   when: install_from_dir

--- a/tasks/setup-confluent-kafka.yml
+++ b/tasks/setup-confluent-kafka.yml
@@ -46,6 +46,7 @@
     copy:
       src: "{{local_kafka_path}}"
       dest: "/tmp"
+      mode: 0644
   - name: Get a list of the packages copied over
     find:
       paths: "/tmp/{{local_kafka_path | basename}}"

--- a/tasks/setup-kafka-server-properties.yml
+++ b/tasks/setup-kafka-server-properties.yml
@@ -4,7 +4,7 @@
 # the server.properties file and schema-registry.properties
 # files correctly
 - set_fact:
-    kfka_nodes: "{{kafka_nodes | map('extract', hostvars, [('ansible_' + kafka_iface), 'ipv4', 'address']) | list}}"
+    kfka_nodes: "{{kafka_nodes | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
 - set_fact:
     num_hosts: "{{ kfka_nodes | length }}"
 - block:
@@ -12,7 +12,7 @@
     replace:
       dest: "{{kafka_config_dir}}/server.properties"
       regexp: '^\#(([a-zA-Z]*.?)listeners=PLAINTEXT://).*(:9092)$'
-      replace: '\g<1>{{kafka_addr}}\g<3>'
+      replace: '\g<1>{{api_addr}}\g<3>'
   - name: Configure server to use the defined data directory
     lineinfile:
       dest: "{{kafka_config_dir}}/server.properties"
@@ -22,7 +22,7 @@
     lineinfile:
       dest: "{{kafka_config_dir}}/server.properties"
       regexp: "^host.name="
-      line: "host.name={{kafka_addr}}"
+      line: "host.name={{api_addr}}"
     when: (zk_nodes | default([])) != []
   - name: Setup broker.id if deploying kafka cluster
     lineinfile:
@@ -30,12 +30,12 @@
       regexp: "^broker.id="
       line: "broker.id={{item.0}}"
     with_indexed_items: "{{kfka_nodes}}"
-    when: "(num_hosts | int > 1) and ('{{iface_addr}}' == '{{item.1}}')"
+    when: "(num_hosts | int > 1) and ('{{data_addr}}' == '{{item.1}}')"
   - name: setup confluent-schema-registry listener if deploying a Confluent cluster
     replace:
       dest: "{{schema_registry_config_dir}}/schema-registry.properties"
       regexp: '^(listeners=http://).*(:.*)$'
-      replace: '\g<1>{{kafka_addr}}\g<2>'
+      replace: '\g<1>{{api_addr}}\g<2>'
     when: schema_registry_config_dir is defined and zk_nodes is defined and zk_nodes != []
   - name: setup kafkastore connection URL if deploying a Confluent cluster
     lineinfile:

--- a/vars/kafka.yml
+++ b/vars/kafka.yml
@@ -16,8 +16,12 @@ kafka_distro: confluent
 # the directory where the Kafka logs will be written
 kafka_data_dir: /var/lib
 
-# the interface Kafka should listen on when running
-kafka_iface: eth0
+# the names of the interfaces to use for by the Kafka servers; the "data"
+# interface is the private interface that is used to communicate with the
+# (external) Zookeeper ensemble, while the "api" interface is the interface
+# that the Kafka servers listen on for connections from clients
+api_iface: "eth0"
+data_iface: "eth0"
 
 # the following parameters are only used when provisioning an instance
 # of the apache distribution, but are uncommented here (regardless) to


### PR DESCRIPTION
The changes in this pull request modify the existing playbook; adding support for separation between a private network (the data network used by the cluster to communicate) and a public network (the API network that the cluster listens on for client connections). In situations where this separation is not important, the two parameters used to define these networks can simply be set to the same network interface, eg. `eth0` (in fact, this is how the defaults defined in the `vars/kafka.yml` file are setup).

This pull request also includes a fix for a couple of minor bugs (involving the permissions set when the kafka distribution files are copied over from the Ansible host) that was discovered when deploying Kafka to a RHEL OSP cluster recently

Finally, this pull request also contains a separate (unrelated) change to how a local mirror is passed into the playbook (in situations where access to the standard yum repositories is not possible). The mirror is now defined as a URL instead of a hostname/IP address (to reflect recent changes in the underlying `common-roles/add-local-repository` role). This should make it easier to support whatever directory structure was used when defining the local repository.