### PR TITLE
Modifications to use new build-app-host-groups common role

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -305,12 +305,7 @@ if kafka_addr_array.size > 0
       config.vm.define machine_addr do |machine|
         # Create a two private networks, which each allow host-only access to the machine
         # using a specific IP.
-        if machine_addr
-          config.vm.network "private_network", ip: machine_addr
-          split_addr = machine_addr.split('.')
-          api_addr = (split_addr[0..1] + [(split_addr[2].to_i + 10).to_s] + [split_addr[3]]).join('.')
-          config.vm.network "private_network", ip: api_addr
-        end
+        machine.vm.network "private_network", ip: machine_addr
         # if it's the last node in the list if input addresses, then provision
         # all of the nodes simultaneously (if the `--no-provision` flag was not
         # set, of course)
@@ -334,12 +329,12 @@ if kafka_addr_array.size > 0
                 proxy_password: proxy_password
               },
               data_iface: "eth1",
-              api_iface: "eth2",
+              api_iface: "eth1",
               kafka_distro: options[:kafka_distro],
               yum_repo_url: options[:yum_repo_url],
               host_inventory: kafka_addr_array,
               reset_proxy_settings: options[:reset_proxy_settings],
-              inventory_type: "static"
+              cloud: "vagrant"
             }
             # if a value was found for `local_kafka_dist_dir`, then pass it into
             # the playbook as an extra variable, otherwise if a value was found

--- a/site.yml
+++ b/site.yml
@@ -1,129 +1,29 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-# If we're running this command for to build a cluster in an AWS or
-# OpenStack cloud, then use the `ec2` or `openstack` command to (depending
-# on the `cloud` we're deploying to) gather the dynamic inventory information
-# that we need to build our Zookeeper host group (and build it)
-- name: Create Zookeeper host group from AWS or OpenStack inventory
+# First, build our kafka and zookeeper host groups
+- name: Create kafka and zookeeper host groups
   hosts: "{{host_inventory}}"
   gather_facts: no
   tasks:
-    # run these commands to add the zookeeper host group for an aws cloud
-    - block:
-      - name: Run ec2 command to gather inventory information
-        local_action: "shell common-utils/inventory/aws/ec2"
-        register: di_output
-      - set_fact:
-          di_output_json: "{{di_output.stdout | from_json}}"
-      - set_fact:
-          cloud_nodes: "{{di_output_json | json_query('tag_Cloud_' + cloud)}}"
-          tenant_nodes: "{{di_output_json | json_query('tag_Tenant_' + tenant)}}"
-          project_nodes: "{{di_output_json | json_query('tag_Project_' + project)}}"
-          domain_nodes: "{{di_output_json | json_query('tag_Domain_' + domain)}}"
-          application_nodes: "{{di_output_json | json_query('tag_Application_zookeeper')}}"
-      - set_fact:
-          zookeeper_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(domain_nodes) | intersect(application_nodes)}}"
-      - add_host:
-          name: "{{item}}"
-          groups: "zookeeper"
-          ansible_ssh_user: "{{ansible_user}}"
-          ansible_ssh_private_key_file: "{{private_key_path}}/{{cloud}}-{{di_output_json | json_query('_meta.hostvars.\"' + item + '\".ec2_key_name')}}-private-key.pem"
-        with_items: "{{zookeeper_nodes}}"
-      when: not (inventory_type is undefined or inventory_type == "static") and cloud == "aws"
-      run_once: true
-    # or run these commands to add the zookeeper host group for an osp cloud
-    - block:
-      - name: Run openstack command to gather inventory information
-        local_action: "shell common-utils/inventory/osp/openstack"
-        register: di_output
-      - set_fact:
-          di_output_json: "{{di_output.stdout | from_json}}"
-      - set_fact:
-          cloud_nodes: "{{(di_output_json | json_query('[\"meta-Cloud_' + cloud + '\"]')).0}}"
-          tenant_nodes: "{{(di_output_json | json_query('[\"meta-Tenant_' + tenant + '\"]')).0}}"
-          project_nodes: "{{(di_output_json | json_query('[\"meta-Project_' + project + '\"]')).0}}"
-          domain_nodes: "{{(di_output_json | json_query('[\"meta-Domain_' + domain + '\"]')).0}}"
-          application_nodes: "{{(di_output_json | json_query('[\"meta-Application_zookeeper\"]')).0}}"
-      - set_fact:
-          zookeeper_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(domain_nodes) | intersect(application_nodes)}}"
-      - add_host:
-          name: "{{item}}"
-          groups: "zookeeper"
-          ansible_ssh_user: "{{ansible_user}}"
-          ansible_ssh_private_key_file: "{{private_key_path}}/{{di_output_json | json_query('_meta.hostvars.\"' + item + '\".openstack.key_name')}}.pem"
-        with_items: "{{zookeeper_nodes}}"
-      when: not (inventory_type is undefined or inventory_type == "static") and cloud == "osp"
-      run_once: true
+    - include_role:
+        name: build-app-host-groups
+      vars:
+        host_group_list:
+          - name: kafka
+          - name: zookeeper
+      when: cloud == 'aws' or cloud == 'osp'
+    - include_role:
+        name: build-app-host-groups
+      vars:
+        host_group_list:
+          - { name: kafka, node_list: "{{host_inventory}}" }
+          - { name: zookeeper, inventory: "{{zookeeper_inventory}}", node_list: "{{zookeeper_nodes}}" }
+      when: cloud == "vagrant"
 
-# If we're running this command for to build a cluster in an AWS or
-# OpenStack cloud, then use the `ec2` or `openstack` command to (depending
-# on the `cloud` we're deploying to) gather the dynamic inventory information
-# that we need to build our Kafka host group (and build it)
-- name: Create Kafka host group from AWS or OpenStack inventory
-  hosts: "{{host_inventory}}"
-  gather_facts: no
-  tasks:
-    # run these commands to add the kafka host group for an aws cloud
-    - block:
-      - set_fact:
-          application_nodes: "{{di_output_json | json_query('tag_Application_' + application)}}"
-      - set_fact:
-          kafka_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(domain_nodes) | intersect(application_nodes)}}"
-      - add_host:
-          name: "{{item}}"
-          groups: "kafka"
-          ansible_ssh_user: "{{ansible_user}}"
-          ansible_ssh_private_key_file: "{{private_key_path}}/{{cloud}}-{{di_output_json | json_query('_meta.hostvars.\"' + item + '\".ec2_key_name')}}-private-key.pem"
-        with_items: "{{kafka_nodes}}"
-      when: not (inventory_type is undefined or inventory_type == "static") and cloud == "aws"
-      run_once: true
-    # or run these commands to add the kafka host group for an osp cloud
-    - block:
-      - set_fact:
-          application_nodes: "{{(di_output_json | json_query('[\"meta-Application_' + application + '\"]')).0}}"
-      - set_fact:
-          kafka_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(domain_nodes) | intersect(application_nodes)}}"
-      - add_host:
-          name: "{{item}}"
-          groups: "kafka"
-          ansible_ssh_user: "{{ansible_user}}"
-          ansible_ssh_private_key_file: "{{private_key_path}}/{{di_output_json | json_query('_meta.hostvars.\"' + item + '\".openstack.key_name')}}.pem"
-        with_items: "{{kafka_nodes}}"
-      when: not (inventory_type is undefined or inventory_type == "static") and cloud == "osp"
-      run_once: true
-
-# Otherwise, build our Zookeeper host group from the static inventory
-# information that was passed in
-- name: Create Zookeeper host group from input zookeeper_nodes list
-  hosts: "{{host_inventory}}"
-  gather_facts: no
-  tasks:
-    - add_host:
-        name: "{{item}}"
-        groups: "zookeeper"
-        ansible_ssh_host: "{{((((zookeeper_inventory | default({}))[item] | default({})).ansible_ssh_host) | default(item))}}"
-        ansible_ssh_port: "{{((((zookeeper_inventory | default({}))[item] | default({})).ansible_ssh_port) | default(22))}}"
-        ansible_ssh_user: "{{((((zookeeper_inventory | default({}))[item] | default({})).ansible_ssh_user) | default(ansible_user))}}"
-        ansible_ssh_private_key_file: "{{((((zookeeper_inventory | default({}))[item] | default({})).ansible_ssh_private_key_file) | default(ansible_ssh_private_key_file))}}"
-      with_items: "{{zookeeper_nodes | default([])}}"
-      when: inventory_type == "static"
-      run_once: true
-
-# And build our Kafka host group from the static inventory
-# information that was passed in
-- name: Create Kafka host group from input host_inventory list
-  hosts: "{{host_inventory}}"
-  gather_facts: no
-  tasks:
-    - block:
-      - set_fact:
-          kafka_nodes: "{{host_inventory}}"
-      - add_host:
-          name: "{{item}}"
-          groups: "kafka"
-        with_items: "{{kafka_nodes}}"
-      when: inventory_type == "static"
-      run_once: true
+# Collect some Zookeeper related facts
+- name: Gather facts from Zookeeper host group (if defined)
+  hosts: zookeeper
+  tasks: []
 
 # Collect some Zookeeper related facts and determine the "private" IP addresses of
 # the nodes in the Zookeeper ensemble (from their "public" IP addresses and the `data_iface`


### PR DESCRIPTION
The changes in this pull request modify the playbook used to invoke the `dn-kafka` role so that it uses the new `build-app-host-groups` common role to construct the appropriate kafka and zookeeper host groups (regardless of whether the inventory for the playbook run is being gathered dynamically from an AWS or OpenStack cloud or statically from a set of inventory facts provided by vagrant). Specifically, this pull request:

* Modifies the existing `Vagrantfile` to ensure that a `cloud: "vagrant"` extra variable is passed into the playbook instead of the old `inventory: "static"` extra variable (to indicate that the playbook is being invoked using static inventory from vagrant)
* Modified the existing `Vagrantfile` to only allocate a single private network interface for each VM and use the name of that device (`eth1`) for both the data and api networks that vagrant passes into the playbook
* Modifies the playbook contained in the existing `site.yml` file to use the `build-app-host-groups` common role to build the `kafka` and `zookeeper` host groups.

The changes in this pull request should bring the `dn-kafka` playbook in line with the other playbooks that we are modifying to take advantage of the new `build-app-host-groups` common role.