### PR TITLE
Modifications to standardize the playbook and install from an RPM bundle

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -48,8 +48,6 @@
   # interfaces on the Kafka node(s) are up by restarting the network, then gather the facts
   # from our Kafka node(s)
   pre_tasks:
-    - set_fact:
-        zk_nodes: "{{(zookeeper_nodes | default([])) | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
     - name: Ensure the network interfaces are up on our Kafka node(s)
       service:
         name: network
@@ -57,6 +55,30 @@
       become: true
     - name: Gather facts from the Kafka node(s)
       setup:
+    # next, we obtain the interface names for our data_iface
+    # and api_iface (provided an interface description was provided for each)
+    - include_role:
+        name: get-iface-names
+      vars:
+        iface_descriptions: "{{iface_description_array}}"
+      when: not (iface_description_array is undefined or iface_description_array == [])
+    # and now that we know we have our data_iface identified, we can construct
+    # the list of zk_nodes (the data_iface IP addresses of our zookeeper_nodes)
+    - set_fact:
+        zk_nodes: "{{(zookeeper_nodes | default([])) | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
+    # if we're provisioning a RHEL machine, then we need to ensure that
+    # it's subscribed before we can install anything (if it hasn't been
+    # registered already, of course, if that's the case then we can skip
+    # this step)
+    - block:
+      - redhat_subscription:
+          state: present
+          username: "{{rhel_username}}"
+          password: "{{rhel_password}}"
+          consumer_id: "{{rhel_consumer_id}}"
+        become: true
+        when: rhel_username is defined and rhel_password is defined and rhel_consumer_id is defined
+      when: ansible_distribution == 'RedHat'
   # Now that we have all of the facts we need, we can run the roles that are used to
   # deploy and configure Kafka
   roles:

--- a/site.yml
+++ b/site.yml
@@ -42,17 +42,15 @@
     - vars/kafka.yml
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union(kafka_package_list) | union((install_packages_by_tag|default({})).kafka|default([])) }}"
-  # First, determine what the "private" IP addresses of the Zookeeper ensemble are from
-  # the "public" IP addresses that were passed in for this ensemble and the interface name
-  # that we'll be configuring Kafka to listen on.  Once that's done, ensure that all of the
-  # interfaces on the Kafka node(s) are up by restarting the network, then gather the facts
-  # from our Kafka node(s)
+  # First, restart the network (unless the skip_network_restart was set)
+  # and gather some facts about our Kafka node(s)
   pre_tasks:
     - name: Ensure the network interfaces are up on our Kafka node(s)
       service:
         name: network
         state: restarted
       become: true
+      when: not (skip_network_restart is defined or skip_network_restart)
     - name: Gather facts from the Kafka node(s)
       setup:
     # next, we obtain the interface names for our data_iface

--- a/site.yml
+++ b/site.yml
@@ -17,7 +17,7 @@
       vars:
         host_group_list:
           - { name: kafka, node_list: "{{host_inventory}}" }
-          - { name: zookeeper, inventory: "{{zookeeper_inventory}}", node_list: "{{zookeeper_nodes}}" }
+          - { name: zookeeper, inventory: "{{zookeeper_inventory | default({})}}", node_list: "{{zookeeper_nodes | default([])}}" }
       when: cloud == "vagrant"
 
 # Collect some Zookeeper related facts

--- a/tasks/setup-confluent-kafka.yml
+++ b/tasks/setup-confluent-kafka.yml
@@ -4,67 +4,90 @@
 # repository link was provided and we also know if we're installing Confluent
 # from a local directory on the Ansible node (or not)
 - set_fact:
-    local_confluent_repository: true
-    when: item.key == 'confluent'
-    with_dict: "{{local_repository_keys | default({})}}"
-- set_fact:
     install_from_dir: "{{not(local_kafka_path is undefined or local_kafka_path is none or local_kafka_path | trim == '')}}"
-# if we're not installing confluent from a local directory and either a local repository
-# wasn't specified or a local repository was specified but the key for the confluent packages
-# wasn't found in the list of keys retrieved from that repository, then we should setup our
-# nodes to retrieve the Confluent packages from the main Confluent yum repository
+- set_fact:
+    install_from_url: "{{not(kafka_url is undefined or kafka_url is none or kafka_url | trim == '')}}"
+  when: not(install_from_dir)
+# if we're not installing confluent from a local directory or an RPM bundle
+# (passed in via the 'kafka_url' parameter), then we should prepare to install
+# Kafka from the standrad Confluent repository, then installing the packages
+# needed from that repository
 - block:
   - name: "Add the confluent RPM key to our list of trusted RPM keys"
-    become: true
     rpm_key:
       key: https://packages.confluent.io/rpm/3.1/archive.key
       state: present
       validate_certs: no
     environment: "{{environment_vars}}"
   - name: Create a confluent yum repository file
-    become: true
     template:
       src: ../templates/confluent-repo.j2
       dest: /etc/yum.repos.d/confluent.repo
       mode: 0644
-  when: not(install_from_dir) and (local_confluent_repository is undefined or not(local_confluent_repository))
-# if we're installing from a repository (either a local repository or the standard
-# Confluent repository), then install the Confluent package from that repository
-- block:
   - name: Install confluent from repository
     yum:
       name: "{{confluent_package_name}}"
       state: present
     environment: "{{environment_vars}}"
   become: true
-  when: not(install_from_dir)
-# otherwise, if we're installing from a local directory on the Ansible node
-# that we're running this playbook from, copy over the files from that directory
-# to a temporary directory and and install the Confluent packages from those files
+  when: not(install_from_dir) and (install_from_url is undefined or not(install_from_url))
+# otherwise, if we're installing from a bundled set of URLs that will be
+# downloaded from a URL or we're installing from a set of RPM files in a local
+# directory on the Ansible node that we're running this playbook from; in the
+# first case we need to download and unpack the bundled RPM files into a '/tmp'
+# directory, while in the second we need to copy over the files from that
+# directory to a '/tmp' directory; in both cases we then need to install the
+# Confluent packages from that directory locally
 - block:
-  - name: Copy confluent files from a local directory to /tmp on remote machine
+  - name: Download the RPM bundle to the /tmp directory
+    get_url:
+      url: "{{kafka_url}}"
+      dest: /tmp
+      mode: 0644
+      validate_certs: no
+    environment: "{{environment_vars}}"
+  - set_fact:
+      archive_filename: "{{kafka_url | basename}}"
+  - set_fact:
+      local_filename: "{{archive_filename.split('.').0}}"
+  - name: Unpack kafka distribution into "{{kafka_dir}}"
+    unarchive:
+      copy: no
+      src: "/tmp/{{archive_filename}}"
+      dest: "/tmp"
+      list_files: yes
+    register: unarchive_out
+  - set_fact:
+      local_filename: "{{unarchive_out.files[0]}}"
+  become: true
+  when: install_from_url is defined and install_from_url
+- block:
+  - name: Copy confluent files from a local directory to /tmp
     copy:
       src: "{{local_kafka_path}}"
       dest: "/tmp"
       mode: 0644
+  - set_fact:
+      local_filename: "{{local_kafka_path | basename}}"
+  become: true
+  when: install_from_dir
+- block:
   - name: Get a list of the packages copied over
     find:
-      paths: "/tmp/{{local_kafka_path | basename}}"
+      paths: "/tmp/{{local_filename}}"
       patterns: "*.rpm"
     register: rpm_list
   - name: Install all of the packages copied over
-    become: true
     yum:
       name: "{{rpm_list.files | map(attribute='path') | list | join(',')}}"
       state: present
-  when: install_from_dir
+  become: true
+  when: install_from_dir or (install_from_url is defined and install_from_url)
 # Now that we've installed the packages that we need, setup the appropriate `log`
 # directories for Kafka (and for Zookeeper in the case of a single-node deployment);
 # finally, finish by setting up some facts that we'll need later in our playbook
-- set_fact: log_dir_location="/var/lib"
 - name: Set fact for the log directory location
-  set_fact: log_dir_location="{{kafka_data_dir}}"
-  when: not (kafka_data_dir is undefined or kafka_data_dir is none or kafka_data_dir | trim == '')
+  set_fact: log_dir_location="{{kafka_data_dir | default('/var/lib')}}"
 - block:
   - name: "Create {{log_dir_location}}/kafka directory"
     become: true
@@ -87,6 +110,19 @@
       group: kafka
     when: (zk_nodes | default([])) == []
   become: true
+# cleanup the temporary files created
+- name: Remove downloaded RPM bundle
+  file:
+    path: "/tmp/{{archive_filename}}"
+    state: absent
+  become: true
+  when: install_from_url is defined and install_from_url
+- name: Remove directory created in /tmp directory
+  file:
+    path: "/tmp/{{local_filename}}"
+    state: absent
+  become: true
+  when: install_from_dir or (install_from_url is defined and install_from_url)
 # finally, set values for kafka_bin_dir, kafka_config_dir, kafka_topics_cmd, and
 # schema_registry_config_dir
 - name: Set a few facts that are used later in the playbook

--- a/vars/kafka.yml
+++ b/vars/kafka.yml
@@ -42,12 +42,6 @@ confluent_package_name: "confluent-platform-oss-2.11"
 kafka_topics: ["metrics", "logs"]
 kafka_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
 
-# used to add extra repositories to the list of repositories in the
-# `local.repo` file that is deployed to a node when we're adding a
-# local repository to use in the provisioning process
-#local_repository_url: http://{{yum_repository}}/local.repo
-#local_repository_extra_keys: http://{{yum_repository}}/local-keys.json
-
 # used to install kafka from the RPM files in a local directory (when deploying
 # the Confluent Kafka dstribution), if it exists and is not an empty string
 local_kafka_path: ""


### PR DESCRIPTION
The changes in this pull request bring the `dn-kafka` playbook in line with the other playbooks we are using today.  Specifically, this PR:

* adds in a default for the `zookeeper_inventory` and `zookeeper_nodes` parameters that are used when constructing host groups from a static inventory; this is critical for supporting single-node deployments (where there is no pre-existing zookeeper ensemble to pass in using these parameters).
* adds a flag that can be used to skip the 'network restart' task in the playbook; while this task still runs by default, by setting the new `skip_network_restart` to `true` in the playbook run it will be skipped (something that might be useful for deployments where we know the nodes have already been setup properly, with IP addresses assigned to all of the NICs before the playbook is run).
* adds a task to the playbook run that can be used to register a RHEL7 node; this task is only executed if values are provided for the associated `rhel_username`, `rhel_password` and `rhel_consumer_id` parameters that are needed to register the node, and if any of these parameters are not defined (or if the node being provisioned is not a RedHat node) then that task will be skipped.
* brings the `common-roles` submodule up to date so that the playbook can use the new `get-iface-names` common role to obtain the names of a set of interfaces based on an interface description array
* adds code to the playbook to support passing in that array of interface descriptions (where each interface description is a hash map consisting of a `type`, `val`, and `as_var` value, where the last value is the name of the variable that the user wants that interface's name returned as; for example (in JSON), the following hash map can be used to obtain the names of two interfaces using the CIDR value associated with each NIC (the first name being returned as the `data_iface` and the second as the `api_iface`):
    ```
    iface_description_array: [
        { as_var: 'data_iface', type: 'cidr', val: '192.168.34.0/24' },
        { as_var: 'api_iface', type: 'cidr', val: '192.168.44.0/24'  }
    ]
    ```

In addition to these changes, this pull request also adds the ability to download and install the Confluent Kafka distribution from a gzipped tarfile containing the RPM files that make up this distribution (what we've called an RPM bundle in the playbook associated with this role).  This should make it simpler to save the Confluent distribution in a form that we can download from an internal website for those situations where access to the external network is not possible and a local mirror of the Confluent RPM repository is not available.

With these changes in place, this role now supports the same capabilities that are supported by the other roles in use today.