### PR TITLE
Adds a 'rolling removal' to the topic removal process

### DIFF
--- a/roles/modify-topics/files/remove_topic_dirs.yml
+++ b/roles/modify-topics/files/remove_topic_dirs.yml
@@ -23,7 +23,7 @@
     shell: "tar -C {{kafka_data_dir}}/kafka -jcf {{kafka_data_dir}}/kafka/{{topic}}-archive-{{filename_timestamp}}.tar.bz2 {{topic_dirs | join(' ')}}"
     args:
       warn: no
-    when: construct_archive
+    when: construct_archive and topic_dirs != []
   - name: Remove matching topic directories from Kafka nodes
     file:
       path: "{{kafka_data_dir}}/kafka/{{item}}"

--- a/roles/modify-topics/files/remove_topics_from_host.yml
+++ b/roles/modify-topics/files/remove_topics_from_host.yml
@@ -1,0 +1,53 @@
+# (c) 2016 DataNexus Inc.  All Rights Reserved
+---
+# Then shut down the Kafka service on a node in our cluster
+- name: Stop kafka service on {{current_host}}
+  service:
+    name: kafka
+    state: stopped
+  become_user: root
+# Find and remove any directories associated with that topic from the nodes
+# in our cluster
+- include: ../files/remove_topic_dirs.yml static=no
+  vars:
+    backup_topics: "{{action_hash.backup_topics | default(false)}}"
+  with_items: "{{action_hash.topic_list | default([])}}"
+  loop_control:
+    loop_var: topic
+# If this is the first node in the cluster, then remove the associated metadata
+# from the Zookeeper instance/ensemble by connecting to one of the instances
+# (via SSH if it's a remote instance/ensemble) from the Ansible host and running
+# the appropriate `zkCli.sh rmr ...` command
+- block:
+  - name: If first node and remote Zookeeper ensemble, remove metadata from Zookeeper ensemble
+    local_action: shell ssh -i '{{hostvars[zk_node].ansible_ssh_private_key_file}}' -p '{{hostvars[zk_node].ansible_ssh_port}}' {{hostvars[zk_node].ansible_ssh_user}}@{{hostvars[zk_node].ansible_ssh_host}} 'for topic in {{action_hash.topic_list | join(' ')}}; do sudo -u zookeeper {{remote_zookeeper_dir}}/bin/zkCli.sh rmr /brokers/topics/$topic; done'
+    register: test_output
+    become: false
+    failed_when: false
+    run_once: true
+    when: zk_node != 'localhost' and (action_hash.topic_list | default([])) != []
+  # Remove the associated Zookeeper node from the local Zookeeper instance by running
+  # the appropriate `zkCli.sh rmr ...` command (locally)
+  - name: If first node and bundled Zookeeper instance, remove metadata from Zookeeper instance
+    shell: "{{lcl_zk_shell_cmd}} localhost:2181 rmr /brokers/topics/{{item}}"
+    register: test_output
+    failed_when: false
+    with_items: "{{action_hash.topic_list | default([])}}"
+    run_once: true
+    when: zk_node == 'localhost'
+  when: current_host == play_hosts[0]
+# now that the topic has been removed from both Zookeeper and the nodes in our
+# cluster it's safe to restart the Kafka service; when complete the topic will
+# no longer show up on the cluster's list of topics
+- name: Start kafka service on {{current_host}}
+  service:
+    name: kafka
+    state: started
+  become_user: root
+# and pause for a configurable number of seconds (by default, will pause for
+# 5 seconds) to make sure that this host is running before we continue with
+# the next host in teh cluster
+- name: Pause for {{action_hash.seconds_between_hosts | default(5)}} seconds between hosts
+  pause:
+    seconds: "{{action_hash.seconds_between_hosts | default(5)}}"
+  when: not (current_host == last_host)

--- a/roles/modify-topics/tasks/main.yml
+++ b/roles/modify-topics/tasks/main.yml
@@ -44,7 +44,7 @@
   - block:
     # First, mark the topic for deletion by running the appropriate command on one of
     # the nodes in our Kafka cluster
-    - name: Removing topics from the Kafka cluster
+    - name: Remove topics from the Kafka cluster
       shell: "{{kafka_topics_cmd}} --delete --zookeeper={{zk_node}}:2181 --topic={{item}}"
       register: command_result
       failed_when:
@@ -54,47 +54,20 @@
         - "command_result.rc != 0"
       with_items: "{{action_hash.topic_list | default([])}}"
       run_once: true
-    # Then shut down the Kafka service on all of the nodes in our cluster
-    - name: Stop kafka service
-      service:
-        name: kafka
-        state: stopped
-      become_user: root
-    # Find and remove any directories associated with that topic from the nodes
-    # in our cluster
-    - include: ../files/remove_topic_dirs.yml static=no
-      vars:
-        backup_topics: "{{action_hash.backup_topics | default(false)}}"
-      with_items: "{{action_hash.topic_list | default([])}}"
+    # now that the topics have been marked for deletion, roll through the
+    # members of the cluster and remove the topic directories from each of
+    # them (in turn); the metadata associated with those topics will also be
+    # removed from the Zookeeper instance/ensemble, but only after the topic
+    # directories have been removed from the first node in the cluster
+    - set_fact:
+        last_host: "{{play_hosts[(play_hosts|length)-1]}}"
+    - name: Perform rolling removal of topic directories and metadata
+      include: ../files/remove_topics_from_host.yml static=no
+      run_once: true
+      delegate_to: "{{current_host}}"
+      with_items: "{{play_hosts}}"
       loop_control:
-        loop_var: topic
-    # Remove the associated Zookeeper node from the Zookeeper ensemble by connecting
-    # to one of the instances via SSH from the Ansible host and runnign the appropriate
-    # `zkCli.sh rmr ...` command
-    - name: Remove corresponding nodes from remote Zookeeper ensemble
-      local_action: shell ssh -i '{{hostvars[zk_node].ansible_ssh_private_key_file}}' -p '{{hostvars[zk_node].ansible_ssh_port}}' {{hostvars[zk_node].ansible_ssh_user}}@{{hostvars[zk_node].ansible_ssh_host}} 'for topic in {{action_hash.topic_list | join(' ')}}; do sudo -u zookeeper {{remote_zookeeper_dir}}/bin/zkCli.sh rmr /brokers/topics/$topic; done'
-      register: test_output
-      become: false
-      failed_when: false
-      run_once: true
-      when: zk_node != 'localhost' and (action_hash.topic_list | default([])) != []
-    # Remove the associated Zookeeper node from the local Zookeeper instance by running
-    # the appropriate `zkCli.sh rmr ...` command (locally)
-    - name: Remove corresponding nodes from bundled Zookeeper instance
-      shell: "{{lcl_zk_shell_cmd}} localhost:2181 rmr /brokers/topics/{{item}}"
-      register: test_output
-      failed_when: false
-      with_items: "{{action_hash.topic_list | default([])}}"
-      run_once: true
-      when: zk_node == 'localhost'
-    # now that the topic has been removed from both Zookeeper and the nodes in our
-    # cluster it's safe to restart the Kafka service; when complete the topic will
-    # no longer show up on the cluster's list of topics
-    - name: Start kafka service
-      service:
-        name: kafka
-        state: started
-      become_user: root
+        loop_var: current_host
     # Finally, if this is an Apache Kafka distribution, delete the topic one more time
     # (this should ensure it disappears from such instances; without this step it seems
     # to come back in a "marked for deletion" state if the topic is created again later)

--- a/tasks/setup-kafka-server-properties.yml
+++ b/tasks/setup-kafka-server-properties.yml
@@ -30,7 +30,7 @@
       regexp: "^broker.id="
       line: "broker.id={{item.0}}"
     with_indexed_items: "{{kfka_nodes}}"
-    when: "(num_hosts | int > 1) and ('{{data_addr}}' == '{{item.1}}')"
+    when: (num_hosts | int > 1) and (data_addr == item.1)
   - name: setup confluent-schema-registry listener if deploying a Confluent cluster
     replace:
       dest: "{{schema_registry_config_dir}}/schema-registry.properties"


### PR DESCRIPTION
The changes in this PR separate out the code that removes topics from the cluster so that the topic removal code (along with the code that stops/starts the Kafka service on each node of the cluster) is invoked in series (with each node of the cluster modified sequentially, ensuring that for a multi-node cluster the Kafka cluster will continue to run even as each node in the cluster is modified). Specifically, the new code uses the following sequence to remove topics from the cluster:

* The `kafka-topics` command (for a Confluent Kafka cluster) or `kafka-topics.sh` script (for an Apache Kafka cluster) is used to remove the unwanted topics from the cluster
* The playbook then loops through each node in the cluster, removing the corresponding topic-related data directories from each node and removing the related meta-data for those topics from the associated Zookeeper ensemble; specifically:
    * The Kafka service is shut down on each node in the cluster
    * The directories related to the topics being removed (if there are any for that node) are backed up to a bzipped tarfile in the `{{kafka_data_dir}}/kafka` directory if the `backup_topics` flag was set to `true` in the `action_hash` defined for the playbook run
    * The topic-related directories (if there are any for that node) are removed from the `{{kafka_data_dir}}/kafka` directory
    * If this is the first node in the cluster, the meta-data associated with the topics being removed is removed from the Zookeeper ensemble associated with the Kafka cluster
    * The Kafka service is restarted on that node
    * If this is not the last node in the cluster, the playbook pauses for a configurable number of seconds (5 seconds by default) before moving on to the next node in the cluster and repeating this sequence of tasks
* Once the last node in the cluster has been modified (and the Kafka service on that node has restarted), the last step is to remove the topics again using the `kafka-topics.sh` script if the Kafka cluster was built using the Apache Kafka distribution (for Confluent Kafka clusters, this step is unnecessary and, as such, is skipped)

With these changes in place, topics can be removed from a running Kafka cluster without any risk of taking the cluster offline. This should make this playbook much more suitable for managing topics in a production Kafka cluster.