### PR TITLE
Refactoring modify-connectors.yml playbook

### DIFF
--- a/docs/Managing-Connectors.md
+++ b/docs/Managing-Connectors.md
@@ -196,14 +196,14 @@ can be used to restart those same instances (first stopping them, then starting 
 
 Finally, in addition to adding new connnectors to and managing worker instances running in the connector framework on the target nodes of an `ansible-playbook` run, the playbook in this repository also supports management of the connector instances that are deployed to worker instances running in that framework. More specifically, the playbook in this repository supports the following `action` values in the defined `action_hash`:
 
-* **`start`**: starts a new (named) instance of a given connector on one of the workers in the connector framework
+* **`create`**: creates a new (named) instance of a given connector on one of the workers in the connector framework
 * **`restart`**: restarts a running (named) instance of a connector running on one of the workers in the connector framework
 * **`update`**: updates the configuration of an existing (named) instance of a connector running on one of the workers in the connector framework
 * **`pause`**: pauses an existing (named) instance of a connector running on one of the workers in the connector framework; this action is useful when the underlying system that the connector communicates with must be taken down for maintenance, for example
 * **`resume`**: resumes an existing (named, paused) instance of a connector running on one of the workers in the connector framework
-* **`remove`**: removes an existing (named) instance of a connector from one of the workers in the connector framework
+* **`delete`**: deletes an existing (named) instance of a connector from one of the workers in the connector framework
 
-Each of these actions relies on a `name` that must be defined as part of the `action_hash` that is passed into the playbook run (along with one of the `action` values described above). In addition, when starting a new instance of a given connector or updating the configuration of that connector, a `config` hash map must be provided. The details of that `config` hash map will vary greatly depending on the connector type and the specific implementation that is being used. For example, when starting a new instance of the `kafka-connect-solr` instance available provided by [jcustenborder](https://github.com/jcustenborder/kafka-connect-solr), a local variables file that looks something like this would be used:
+Each of these actions relies on a `name` that must be defined as part of the `action_hash` that is passed into the playbook run (along with one of the `action` values described above). In addition, when creating a new instance of a given connector or updating the configuration of that connector, a `config` hash map must be provided. The details of that `config` hash map will vary greatly depending on the connector type and the specific implementation that is being used. For example, when creating a new instance of the `kafka-connect-solr` instance available provided by [jcustenborder](https://github.com/jcustenborder/kafka-connect-solr), a local variables file that looks something like this would be used:
 
 ```bash
 cat local-vars-start-connectors.yml
@@ -211,7 +211,7 @@ cat local-vars-start-connectors.yml
 data_iface: eth0
 api_iface: eth1
 action_hash:
-  action: start
+  action: create
   worker_port: 8083
   connectors:
     - name: solrcloud-metrics
@@ -236,7 +236,7 @@ action_hash:
         "solr.ignore.unknown.fields": false
 ```
 
-As was the case when adding new connectors to the nodes, the `action_hash` used when creating new instance of a given connector type relies on an `action` (which was given a value of `start` in this example) and an array of `connectors`, each of which contains a `name` to use when creating the connector instance and a `config` containing the configuration values required for that connector type. Other than the `connector.class` field that is shown, above, everything else in that `config` hash is implementation specific and the values that are supported and/or required will vary from one connector implementation to another (even for connectors that are intended to talk wtih the same sort of subsystem, a Solr server for example).
+As was the case when adding new connectors to the nodes, the `action_hash` used when creating new instance of a given connector type relies on an `action` (which was given a value of `create` in this example) and an array of `connectors`, each of which contains a `name` to use when creating the connector instance and a `config` containing the configuration values required for that connector type. Other than the `connector.class` field that is shown, above, everything else in that `config` hash is implementation specific and the values that are supported and/or required will vary from one connector implementation to another (even for connectors that are intended to talk wtih the same sort of subsystem, a Solr server for example).
 
 The parameters in each of the `connectors` entries will be used to construct the POST request that will be used to create the named connector instance. It should be noted here that since the RESTful API provided by the workers running in the connector framework must already be up and running for this POST request to succeed, we are assuming in this example that worker is already running in the the connector framework on the target nodes. If the worker is not already running in the connector framework, then any attempt to create new connector instances will fail.
 
@@ -273,7 +273,7 @@ action_hash:
         "solr.ignore.unknown.fields": false
 ```
 
-The remaining actions (restarting, pausing, resuming, and removing named connector instances) are much simpler since they only require that the name of the connector be specified in the `connectors` list; for example this local variables file can be used to pause the two connector instances shown above:
+The remaining actions (restarting, pausing, resuming, and deleting named connector instances) are much simpler since they only require that the name of the connector be specified in the `connectors` list; for example this local variables file can be used to pause the two connector instances shown above:
 
 ```bash
 cat local-vars-pause-connectors.yml
@@ -288,4 +288,4 @@ action_hash:
     - name: solrcloud-logs
 ```
 
-resuming, restarting, or removing these same instances would only require that the `action` shown above be modified (to `resume`, `restart`, or `remove`, respectively).
+resuming, restarting, or removing these same instances would only require that the `action` shown above be modified (to `resume`, `restart`, or `delete`, respectively).

--- a/modify-connectors.yml
+++ b/modify-connectors.yml
@@ -41,6 +41,7 @@
   vars_files:
     - vars/kafka.yml
   vars:
+    - kafka_nodes: "{{groups['kafka']}}"
     - zookeeper_nodes: "{{groups['zookeeper']}}"
   pre_tasks:
     # first, load the local variables file (if one was defined); this will initialize

--- a/roles/modify-connectors/files/get-aws-credentials-handler.yml
+++ b/roles/modify-connectors/files/get-aws-credentials-handler.yml
@@ -1,0 +1,11 @@
+# (c) 2016 DataNexus Inc.  All Rights Reserved
+---
+# Get the AWS credentials associated with the input `ec2_region` from the
+# input `credentials_file`
+- name: Get {{post_install_task.ec2_region}} credentials from {{post_install_task.credentials_file}}
+  include_role:
+    name: get-aws-credentials
+  vars:
+    ec2_region: "{{post_install_task.ec2_region}}"
+    credentials_file: "{{post_install_task.credentials_file}}"
+  run_once: true

--- a/roles/modify-connectors/files/install-template-handler.yml
+++ b/roles/modify-connectors/files/install-template-handler.yml
@@ -1,0 +1,10 @@
+# (c) 2016 DataNexus Inc.  All Rights Reserved
+---
+# Handle the installation of a configuration file from a template associated
+# with a connector that is being added to the system (as a post-installation
+# step in the process of adding a connector)
+- name: Install '{{post_install_task.dest}}' from template
+  template:
+    src: "{{post_install_task.src}}"
+    dest: "{{post_install_task.dest}}"
+    mode: "{{post_install_task.mode | default('0644')}}"

--- a/roles/modify-connectors/tasks/add-connector.yml
+++ b/roles/modify-connectors/tasks/add-connector.yml
@@ -49,7 +49,7 @@
     mime: yes
   register: stat_out
 - set_fact:
-    file_type: "{{stat_out.stat.mime_type}}"
+    file_type: "{{stat_out.stat.mimetype}}"
 # set a fact containing the connector directory and a set of facts based on the mime-type
 # of the file and the file's extension (determined above); these latter facts are used to
 # determine how the file should be handled (we can't just rely on the MIME type since some
@@ -100,7 +100,7 @@
 # directory, copy the files unpacked into the connector directory, and clean up
 # the temporary files we created
 - block:
-  - name: Unpack kafka distribution into /tmp directory
+  - name: Unpack connector distribution into /tmp directory
     unarchive:
       copy: no
       src: "/tmp/{{local_filename}}"
@@ -154,3 +154,12 @@
       state: absent
   become: true
   when: file_has_jar_ext and is_jar_mime_type
+# now that the installation of the connector is complete, handle any
+# post-install tasks that might have been included for the connector
+- block:
+  - name: Handle post-install connector actions
+    include: "../files/{{post_install_task.action}}-handler.yml static=no"
+    with_items: "{{post_install_tasks}}"
+    loop_control:
+      loop_var: post_install_task
+  become: true

--- a/roles/modify-connectors/tasks/main.yml
+++ b/roles/modify-connectors/tasks/main.yml
@@ -19,22 +19,6 @@
       jar_mime_types:
         - 'application/zip'
         - 'application/x-zip'
-  # if the action is 'start-worker', then start the a worker in the connector
-  # framework in distributed mode
-  - include: manage-connector-workers.yml static=no
-    vars:
-      connector_worker_url: "http://{{data_addr}}:{{action_hash.worker_port | default(8083)}}/connectors"
-      key_converter: "{{action_hash.key_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
-      value_converter: "{{action_hash.value_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
-      internal_key_converter: "{{action_hash.internal_key_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
-      internal_value_converter: "{{action_hash.internal_value_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
-      offset_topic: "{{action_hash.offset_topic | default('connect-offsets')}}"
-      config_topic: "{{action_hash.config_topic | default('connect-configs')}}"
-      status_topic: "{{action_hash.status_topic | default('connect-status')}}"
-      rest_port: "{{action_hash.worker_port | default(8083)}}"
-      group_id: "{{action_hash.group_id | default('default_group')}}"
-      action: "{{action_hash.action}}"
-    when: ([(action_hash.action | default (''))] | intersect(['start-worker', 'stop-worker', 'restart-worker'])) != []
   # if the action is 'add', then loop through the connectors that are being
   # added and add each of them, in turn, to the target nodes based on the
   # information in the corresponding 'action_hash' entry
@@ -43,9 +27,44 @@
       connector_name: "{{item.name}}"
       local_connector_file: "{{item.local_file | default('')}}"
       connector_url: "{{item.connector_url | default('')}}"
+      post_install_tasks: "{{item.post_install_tasks | default([])}}"
     with_items: "{{action_hash.connectors | default([])}}"
     when: (action_hash.action | default ('')) == 'add'
-  # if the action is 'start', 'update', 'pause', 'resume', or 'remove' then
+  # if the action is 'start-worker', 'stop-worker', or 'restart-worker', then
+  # start, stop, or restart the defined worker in the connector framework in
+  # distributed mode
+  - include: manage-connector-workers.yml static=no
+    vars:
+      # properties set for key converter
+      key_converter: "{{action_hash.key_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
+      key_converter_schemas_enable: "{{action_hash.key_converter_schemas_enable | default('false')}}"
+      key_converter_schema_registry_url: "{{((action_hash.key_converter_schemas_enable | default('false')) == 'true') | ternary('http://' + api_addr + ':8081','')}}"
+      # properties set for value converter
+      value_converter: "{{action_hash.value_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
+      value_converter_schemas_enable: "{{action_hash.value_converter_schemas_enable | default('false')}}"
+      value_converter_schema_registry_url: "{{((action_hash.value_converter_schemas_enable | default('false')) == 'true') | ternary('http://' + api_addr + ':8081','')}}"
+      # properties set for internal key converter
+      internal_key_converter: "{{action_hash.internal_key_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
+      internal_key_converter_schemas_enable: "{{action_hash.internal_key_converter_schemas_enable | default('false')}}"
+      internal_key_converter_schema_registry_url: "{{((action_hash.internal_key_converter_schemas_enable | default('false')) == 'true') | ternary('http://' + api_addr + ':8081','')}}"
+      # properties set for internal value converter
+      internal_value_converter: "{{action_hash.internal_value_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
+      internal_value_converter_schemas_enable: "{{action_hash.internal_value_converter_schemas_enable | default('false')}}"
+      internal_value_converter_schema_registry_url: "{{((action_hash.internal_value_converter_schemas_enable | default('false')) == 'true') | ternary('http://' + api_addr + ':8081','')}}"
+      # topics used by connectors to store offset, configuration, and status information
+      offset_topic: "{{action_hash.offset_topic | default('connect-offsets')}}"
+      config_topic: "{{action_hash.config_topic | default('connect-configs')}}"
+      status_topic: "{{action_hash.status_topic | default('connect-status')}}"
+      # worker specific configuration parameters
+      rest_port: "{{action_hash.worker_port | default(8083)}}"
+      group_id: "{{action_hash.group_id | default('default_group')}}"
+      worker_name: "{{action_hash.name | default('')}}"
+      worker_classpath: "{{action_hash.worker_classpath | default('')}}"
+      connector_worker_url: "http://{{api_addr}}:{{action_hash.worker_port | default(8083)}}/connectors"
+      # the action we're taking
+      action: "{{action_hash.action}}"
+    when: ([(action_hash.action | default (''))] | intersect(['start-worker', 'stop-worker', 'restart-worker'])) != []
+  # if the action is 'create', 'update', 'pause', 'resume', or 'delete' then
   # loop through the connectors in the 'action_hash' and perform the
   # corresponding action on each of them, in turn, using the information in
   # the corresponding 'action_hash' entry
@@ -53,8 +72,8 @@
     vars:
       connector_name: "{{item.name}}"
       connector_config: "{{item.config | default({})}}"
-      connector_worker_url: "http://{{data_addr}}:{{action_hash.worker_port | default(8083)}}/connectors"
+      connector_worker_url: "http://{{api_addr}}:{{action_hash.worker_port | default(8083)}}/connectors"
       action: "{{action_hash.action}}"
     with_items: "{{action_hash.connectors | default([])}}"
-    when: ([(action_hash.action | default (''))] | intersect(['start', 'restart', 'update', 'pause', 'resume', 'remove'])) != []
+    when: ([(action_hash.action | default (''))] | intersect(['create', 'restart', 'update', 'pause', 'resume', 'delete'])) != []
   when: (action_hash | default({})) != {}

--- a/roles/modify-connectors/tasks/manage-connector-instances.yml
+++ b/roles/modify-connectors/tasks/manage-connector-instances.yml
@@ -8,12 +8,12 @@
     request_body_hash:
       name: "{{connector_name}}"
       config: "{{connector_config}}"
-  when: action == 'start'
+  when: action == 'create'
 - set_fact:
     request_body_hash: "{{connector_config}}"
   when: action == 'update'
 # if we're starting a new instance, then put together a POST command to do so
-- name: Start new {{connector_name}} connector instance
+- name: Create new {{connector_name}} connector instance
   uri:
     headers:
       Content-Type: "application/json"
@@ -24,7 +24,7 @@
     return_content: yes
   register: returned_content
   run_once: true
-  when: action == 'start'
+  when: action == 'create'
 # if we're restarting an existing instance, then put together a POST command
 # to do so
 - name: Restart (running) {{connector_name}} connector instance
@@ -74,7 +74,7 @@
   when: action == 'resume'
 # if we're resuming an existing connector instance, then put together a PUT
 # command to do so
-- name: Remove (existing) {{connector_name}} connector instance from worker
+- name: Delete (existing) {{connector_name}} connector instance from worker
   uri:
     method: DELETE
     url: "{{connector_worker_url}}/{{connector_name}}"
@@ -82,4 +82,4 @@
     return_content: yes
   register: returned_content
   run_once: true
-  when: action == 'remove'
+  when: action == 'delete'

--- a/roles/modify-connectors/tasks/manage-connector-workers.yml
+++ b/roles/modify-connectors/tasks/manage-connector-workers.yml
@@ -2,8 +2,15 @@
 ---
 # if a connector worker is not already running at the named URL, then
 # start a new connector worker in distributed mode
-- set_fact:
+- name: Set some facts we'll use later
+  set_fact:
     kfka_nodes: "{{kafka_nodes | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
+    worker_props_filename: "{{(worker_name != '') | ternary('worker-' + worker_name + '.properties', 'worker.properties')}}"
+    worker_grep_str: "{{(worker_name != '') | ternary(' | grep ' + worker_name, '')}}"
+    worker_cp_prefix: "{{(worker_classpath != '') | ternary('CLASSPATH=\"' + worker_classpath + '\" ', '')}}"
+    kafka_topics_cmd: "{{(kafka_distro == 'apache') | ternary(kafka_dir + '/bin/kafka-topics.sh', 'kafka-topics')}}"
+    zk_node_str: "{{(zk_nodes | default(['localhost'])) | join(':2181,')}}:2181"
+    topic_repl_factor: "{{[3,(kafka_nodes | length)] | min}}"
 - name: Check to see if a connector worker is already running
   uri:
     method: GET
@@ -15,22 +22,24 @@
 # create the topics used to store configurations, offsets, and status (unless
 # they already exist, in which case this action will do nothing); start by
 # retrieving a list of the currently defined topics
-- name: Choose a zookeeper node from the ZK cluster when defined
-  set_fact: zk_node={{zk_nodes | random}}
-  when: zk_nodes is defined and zk_nodes != []
-- set_fact:
-    kafka_topics_cmd: "{{kafka_dir}}/bin/kafka-topics.sh"
-  when: kafka_distro == 'apache'
 - name: Get list of topics currently available
-  shell: "{{kafka_topics_cmd | default('kafka-topics')}} --zookeeper {{zk_node | default('localhost')}}:2181 --list"
+  shell: "{{kafka_topics_cmd}} --zookeeper={{zk_node_str}} --list"
   register: kafka_topics_out
+  when: action == 'start-worker'
 # then, if the list of topics was successfully retrieved, create any of the
 # topics we need that do not exist in the currently defined list of topics
-- debug: msg="{{[offset_topic,config_topic,status_topic]}}"
 - block:
-  - name: Create topics used by the worker instance
-    shell: "{{kafka_topics_cmd | default('kafka-topics')}} --create --zookeeper {{zk_node}}:2181 --replication-factor 1 --partitions 1 --topic {{ item }}"
-    with_items: "{{[offset_topic,config_topic,status_topic] | difference(kafka_topics_out.stdout_lines)}}"
+  - name: Determine which of the worker-related topics need to be created
+    set_fact:
+      list_topics_create: "{{[offset_topic,config_topic,status_topic] | difference(kafka_topics_out.stdout_lines)}}"
+    run_once: true
+  - name: Create topics used by the worker
+    shell: "{{kafka_topics_cmd}} --create --zookeeper={{zk_node_str}} --replication-factor={{topic_repl_factor}} --partitions={{item.partitions}} --topic={{item.name}}"
+    with_items:
+     - { name: "{{offset_topic}}", partitions: 50}
+     - { name: "{{config_topic}}", partitions: 1}
+     - { name: "{{status_topic}}", partitions: 10}
+    when: item.name in list_topics_create
     register: command_result
     failed_when:
       - "'already exists' not in command_result.stdout"
@@ -38,34 +47,80 @@
     run_once: true
     become_user: kafka
   become: true
-  when: kafka_topics_out.rc == 0
+  when: action == 'start-worker' and kafka_topics_out.rc == 0
 # if a worker is not running at the named URL and we've been asked to start
 # a connector worker, then start it
 - block:
   # first, construct a properties file from the worker_properties hash and
   # the cluster configuration
-  - name: Ensure directory for worker.properties file exists
+  - name: Ensure directory for worker properties file exists
     file:
       path: "/etc/kafka-connectors"
       state: directory
       owner: kafka
       group: kafka
       mode: 0755
-  - name: Create worker.properties file
+  - name: Create {{worker_props_filename}} file
     template:
       src: worker.properties.j2
-      dest: /etc/kafka-connectors/worker.properties
+      dest: "/etc/kafka-connectors/{{worker_props_filename}}"
       owner: kafka
       group: kafka
       mode: 0644
-  # then, use that worker.properties file to start the connector worker via
+  # if additional configuration parameters were passed in, then set the corresponding
+  # parameters in the worker properties file
+  - name: Setup additional configuration options
+    lineinfile:
+      dest: "/etc/kafka-connectors/{{worker_props_filename}}"
+      line: "{{item.name}}={{item.value}}"
+      insertafter: "{{item.insertafter}}"
+      state: present
+    with_items:
+      # set flag to enable converter schemas?
+      - name: "key.converter.schemas.enable"
+        value: "{{key_converter_schemas_enable}}"
+        nil_val: "true"
+        insertafter: "^key.converter="
+      - name: "value.converter.schemas.enable"
+        value: "{{value_converter_schemas_enable}}"
+        nil_val: "true"
+        insertafter: "^value.converter="
+      # set schema registry URL?
+      - name: "key.converter.schema.registry.url"
+        value: "{{key_converter_schema_registry_url}}"
+        nil_val: ""
+        insertafter: "^key.converter="
+      - name: "value.converter.schema.registry.url"
+        value: "{{value_converter_schema_registry_url}}"
+        nil_val: ""
+        insertafter: "^value.converter="
+      # set flag to enable internal converter schemas?
+      - name: "internal.key.converter.schemas.enable"
+        value: "{{internal_key_converter_schemas_enable}}"
+        nil_val: "true"
+        insertafter: "^internal.key.converter="
+      - name: "internal.value.converter.schemas.enable"
+        value: "{{internal_value_converter_schemas_enable}}"
+        nil_val: "true"
+        insertafter: "^internal.value.converter="
+      # set internal schema registry URL?
+      - name: "internal.key.converter.schema.registry.url"
+        value: "{{internal_key_converter_schema_registry_url}}"
+        nil_val: ""
+        insertafter: "^internal.key.converter="
+      - name: "internal.value.converter.schema.registry.url"
+        value: "{{internal_value_converter_schema_registry_url}}"
+        nil_val: ""
+        insertafter: "^internal.value.converter="
+    when: item.value != item.nil_val
+  # then, use that '{{worker_props_filename}}' file to start the connector worker via
   # the 'connect-distributed' command in 'daemon mode'
-  - name: Start connector worker
-    shell: "connect-distributed -daemon /etc/kafka-connectors/worker.properties"
+  - name: Start worker
+    shell: "{{worker_cp_prefix}}connect-distributed -daemon /etc/kafka-connectors/{{worker_props_filename}}"
     become_user: kafka
   become: true
   when:
-    - "{{'Connection refused' in returned_content.msg}}"
+    - "'Connection refused' in returned_content.msg"
     - returned_content.status == -1
     - action == 'start-worker'
 # if a worker is running at the named URL and we've been asked to stop
@@ -73,11 +128,12 @@
 - block:
     # get the process ID of the daemon
     - name: Get process ID for daemon
-      shell:  "ps aux | grep org.apache.kafka.connect.cli.ConnectDistributed | grep -v grep | awk '{print $2}'"
+      shell:  "ps aux | grep org.apache.kafka.connect.cli.ConnectDistributed{{worker_grep_str}} | grep -v grep | awk '{print $2}'"
       register: ps_output
     # and kill that process ID
     - name: Kill that process ID
       shell: "kill {{ps_output.stdout_lines.0}}"
+      when: ps_output.stdout_lines != []
   become: true
   when: returned_content.status == 200 and action == 'stop-worker'
 # if the worker is running at the named URL and we've been asked to restart it,
@@ -85,14 +141,15 @@
 - block:
     # get the process ID of the daemon
     - name: Get process ID for daemon
-      shell:  "ps aux | grep org.apache.kafka.connect.cli.ConnectDistributed | grep -v grep | awk '{print $2}'"
+      shell:  "ps aux | grep org.apache.kafka.connect.cli.ConnectDistributed{{worker_grep_str}} | grep -v grep | awk '{print $2}'"
       register: ps_output
     # and kill that process ID
     - name: Kill that process ID and sleep
       shell: "kill {{ps_output.stdout_lines.0}}; sleep 5"
+      when: ps_output.stdout_lines != []
     # and restart the daemon with the same worker properties used when it was created
     - name: Restart the daemon
-      shell: "connect-distributed -daemon /etc/kafka-connectors/worker.properties"
+      shell: "{{worker_cp_prefix}}connect-distributed -daemon /etc/kafka-connectors/{{worker_props_filename}}"
       become_user: kafka
   become: true
   when: returned_content.status == 200 and action == 'restart-worker'

--- a/roles/modify-connectors/templates/worker.properties.j2
+++ b/roles/modify-connectors/templates/worker.properties.j2
@@ -9,7 +9,7 @@ bootstrap.servers={{(kfka_nodes | join(':9092,')) + ':9092'}}
 group.id={{group_id}}
 
 # the host and port that the RESTful API should listen on
-rest.host.name={{data_addr}}
+rest.host.name={{api_addr}}
 rest.port={{rest_port}}
 
 # The converters specify the format of data in Kafka and how to translate it

--- a/roles/modify-topics/tasks/main.yml
+++ b/roles/modify-topics/tasks/main.yml
@@ -29,14 +29,11 @@
     run_once: true
   # Next, pick one of our Zookeeper nodes to use for the commands we'll be running
   - set_fact:
-      rand_zk_node: "{{zk_nodes | random}}"
-    when: zk_nodes is defined and zk_nodes != []
-  - set_fact:
-      zk_node: "{{rand_zk_node | default('localhost')}}"
+      zk_node_str: "{{(zk_nodes | default(['localhost'])) | join(':2181,')}}:2181"
   # If we're creating a new set of topics, then just run the appropriate command on one of
   # the nodes in our Kafka cluster
   - name: Adding topics to the cluster
-    shell: "{{kafka_topics_cmd}} --create --zookeeper={{zk_node}}:2181 --replication-factor={{action_hash.repl_factor | default(1)}} --partitions={{action_hash.partitions | default(1)}} --topic={{item}}"
+    shell: "{{kafka_topics_cmd}} --create --zookeeper={{zk_node_str}} --replication-factor={{action_hash.repl_factor | default(1)}} --partitions={{action_hash.partitions | default(1)}} --topic={{item}}"
     with_items: "{{action_hash.topic_list | default([])}}"
     when: action_hash.action == 'create'
     run_once: true
@@ -45,7 +42,7 @@
     # First, mark the topic for deletion by running the appropriate command on one of
     # the nodes in our Kafka cluster
     - name: Remove topics from the Kafka cluster
-      shell: "{{kafka_topics_cmd}} --delete --zookeeper={{zk_node}}:2181 --topic={{item}}"
+      shell: "{{kafka_topics_cmd}} --delete --zookeeper={{zk_node_str}} --topic={{item}}"
       register: command_result
       failed_when:
         - ('Topic ' + item + ' does not exist') not in command_result.stderr
@@ -72,7 +69,7 @@
     # (this should ensure it disappears from such instances; without this step it seems
     # to come back in a "marked for deletion" state if the topic is created again later)
     - name: For Apache Kafka instances/clusters, remove topics again
-      shell: "{{kafka_topics_cmd}} --delete --zookeeper={{zk_node}}:2181 --topic={{item}}"
+      shell: "{{kafka_topics_cmd}} --delete --zookeeper={{zk_node_str}} --topic={{item}}"
       register: command_result
       failed_when:
         - ('Topic ' + item + ' does not exist') not in command_result.stderr

--- a/run-kafka-console-consumer.sh
+++ b/run-kafka-console-consumer.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-kafka-console-consumer --zookeeper localhost:2181 --topic metrics


### PR DESCRIPTION
The changes in this pull request refactor the existing `modify-connectors.yml` playbook to support execution of additional, post-install actions (after the connector is installed) in the playbook run. The changes in this pull request were made in order to support deployment of the `streamx` connector, which required additional features that were not available in previous versions of this playbook. Specifically:

* Updating the version of the `common-roles` submodule used so that the newly defined `get-aws-credentials` role is available for use in the `modify-connectors.yml` playbook
* Adding two new *handlers* for use in the post-install tasks that were needed to successfully install and configure the `streamx` connector; the first ([roles/modify-connectors/files/get-aws-credentials-handler.yml](roles/modify-connectors/files/get-aws-credentials-handler.yml)) parses a local AWS credential file and returns the credentials in that file that are usable with a given `ec2_region`, while the second ([roles/modify-connectors/files/install-template-handler.yml](roles/modify-connectors/files/install-template-handler.yml)) supports creation of a file on the target machine from a Jinja2 template file on the local (Ansible host) filesystem. These two post-install actions were needed to support deployment of a `/etc/streamx/hdfs-site.xml` file containing the S3 authentication information that the `streamx` connector needs in order to be able to connect to the defined S3 bucket that it will be pushing messages to (from the Kafka topics that is monitoring)
* Changes to the playbook to support additional configuration options that might be needed to properly configure the distributed worker when starting a new worker; these new configuration options (like those defined in the previous version) all have reasonable defaults, to if they are not defined the worker will be configured as it was with previous versions of this playbook

In addition, there are a few minor tweaks to clean up the previous version of this playbook, including:

* Changing the `start` and `remove` actions associated with instantiating new connector instances through the worker's RESTful API to the more consistent (and hopefully clearer) `create` and `delete` actions; the documentation has also been updated to reflect this change in the action that should be used in the `action_hash` when creating and deleting connector instances
* Moving a few blocks of code around so that the blocks of code appear in the same order that they playbook is invoked (adding the connector, starting/stopping/restarting the worker, then starting/stopping/updating/restarting the connector instance) rather than just appearing in the order that we implemented them in; hopefully this new ordering makes it simpler for those trying to understand the code later
* Modifications and bug fixes so that the the worker is started on the `api_iface` rather than the `data_iface` (and the worker communicates with the schema-registry service on that same `api_iface`); previous versions were starting the worker up on the wrong interface and configuring it to try to talk to the schema-registry service on an interface that the schema-registry service was not listening on, and our testing did not use this feature so the issue was not detected
* Changes to the code so that the Zookeeper string used for the commands that are run that communicate with the Zookeeper ensemble include all of the hosts in the ensemble (rather than just selecting a single node from the ensemble to use at random); this should prevent issues that might crop up with the playbook run if it is used when one of the nodes in the ensemble happens to be down
* Removal of the [run-kafka-console-consumer.sh](run-kafka-console-consumer.sh) script from the repository; this script was initially included by mistake and should have been removed long ago

With these changes in place, we can now include support for the `streamx` connector in the list of connectors that we can deploy to our Kafka clusters
